### PR TITLE
🔐 Fix EXCEPTION_ACCESS_VIOLATION during RAW preview extraction failure

### DIFF
--- a/QuickView/ImageLoader.cpp
+++ b/QuickView/ImageLoader.cpp
@@ -4416,8 +4416,8 @@ namespace QuickView {
                             if (thumb->type == LIBRAW_IMAGE_JPEG) {
                                 // Delegate to Codec::JPEG
                                 HRESULT hr = JPEG::Load((uint8_t*)thumb->data, thumb->data_size, ctx, result);
-                                RawProcessor.dcraw_clear_mem(thumb);
                                 if (SUCCEEDED(hr)) {
+                                    RawProcessor.dcraw_clear_mem(thumb);
                                     // Override Metadata
                                     result.metadata.LoaderName = L"LibRaw (Preview)";
                                     OutputDebugStringW(L"[RawCodec] Preview JPEG decoded OK\n");


### PR DESCRIPTION
Fixed a double-free bug in `RawCodec::Load` that was causing `EXCEPTION_ACCESS_VIOLATION` crashes when quickly switching between RAW images.

High risk of crashing the entire application when preview extraction fails (often on unsupported or corrupted embedded JPEGs) because the `dcraw_clear_mem` was called twice on the same memory block.

Solution
Moved the `dcraw_clear_mem` call to only execute when the JPEG decode *succeeds*, ensuring the pointer remains valid for the fallback code and the final memory cleanup block.

---
*PR created automatically by Jules for task [12350791918745661504](https://jules.google.com/task/12350791918745661504) started by @justnullname*