### PR TITLE
🧹 Remove commented out DispatchImageLoad stub

### DIFF
--- a/QuickView/ImageEngine.cpp
+++ b/QuickView/ImageEngine.cpp
@@ -94,9 +94,6 @@ void ImageEngine::RequestFullDecode(const std::wstring& path, ImageID imageId) {
     OutputDebugStringW(buf);
 }
 
-// [Phase 2 Stub Removed (Implemented above)]
-// void ImageEngine::DispatchImageLoad(const std::wstring& path, ImageID imageId, uintmax_t fileSize) { ... }
-
 // [Phase 2] Dispatcher Implementation
 void ImageEngine::DispatchImageLoad(const std::wstring& path, ImageID imageId, uintmax_t fileSize) {
     // 1. Peek Header


### PR DESCRIPTION
Removed the redundant commented-out `DispatchImageLoad` stub in `QuickView/ImageEngine.cpp`. This is a dead code removal task to improve code health.

---
*PR created automatically by Jules for task [1210276158870236007](https://jules.google.com/task/1210276158870236007) started by @justnullname*