### PR TITLE
🐛 [Bug Fix] Fix RAW image orientation loss on second view

### DIFF
--- a/QuickView/ImageLoader.cpp
+++ b/QuickView/ImageLoader.cpp
@@ -4466,6 +4466,12 @@ namespace QuickView {
                                         result.metadata.Width = w;
                                         result.metadata.Height = h;
                                         
+                                        int flip = RawProcessor.imgdata.sizes.flip;
+                                        if (flip == 3) result.metadata.ExifOrientation = 3;
+                                        else if (flip == 5) result.metadata.ExifOrientation = 8;
+                                        else if (flip == 6) result.metadata.ExifOrientation = 6;
+                                        else result.metadata.ExifOrientation = 1;
+
                                         RawProcessor.dcraw_clear_mem(thumb);
                                         return S_OK;
                                     }
@@ -4548,6 +4554,12 @@ namespace QuickView {
                      result.metadata.Width = w;
                      result.metadata.Height = h;
                      
+                     int flip = RawProcessor.imgdata.sizes.flip;
+                     if (flip == 3) result.metadata.ExifOrientation = 3;
+                     else if (flip == 5) result.metadata.ExifOrientation = 8;
+                     else if (flip == 6) result.metadata.ExifOrientation = 6;
+                     else result.metadata.ExifOrientation = 1;
+
                      hr = S_OK;
                 }
                 


### PR DESCRIPTION
This commit fixes an issue where RAW images would lose their correct rotation/orientation when viewed a second time (e.g., when returning to the same image).

**Issue**: The orientation data was correct on the first view (possibly processed by another path or preview, or auto-rotation applied but not saved correctly to metadata) but the `result.metadata.ExifOrientation` was not populated during the LibRaw full decode or embedded bitmap preview extraction paths in `QuickView::Codec::RawCodec::Load`. As a result, when the decoded image was cached and subsequently reloaded, it defaulted to an `ExifOrientation` of 1 (Normal).

**Solution**: Added logic to extract the `flip` value from `RawProcessor.imgdata.sizes.flip` after unpacking the image data and map it to the standard EXIF orientation values:
- `3` -> `3` (180 degrees)
- `5` -> `8` (90 degrees CCW)
- `6` -> `6` (90 degrees CW)
- Default -> `1` (Normal)

This metadata is now correctly saved in `result.metadata.ExifOrientation`, ensuring proper rotation is maintained across views and cache hits.

---
*PR created automatically by Jules for task [12172736273743625029](https://jules.google.com/task/12172736273743625029) started by @justnullname*