### PR TITLE
🧹 [remove commented-out methods in ImageLoader]

### DIFF
--- a/QuickView/ImageLoader.cpp
+++ b/QuickView/ImageLoader.cpp
@@ -5312,14 +5312,6 @@ HRESULT CImageLoader::LoadToMemoryPMR(LPCWSTR filePath, DecodedImage* pOutput, s
     return E_FAIL;
 }
 
-// [v5.3 DEPRECATED] Use DecodeResult.metadata instead
-// std::wstring CImageLoader::GetLastFormatDetails() const {
-//     return g_lastFormatDetails;
-// }
-// 
-// int CImageLoader::GetLastExifOrientation() const {
-//     return g_lastExifOrientation;
-// }
 
 // ============================================================================
 // NEW: Fast Header-Only Parsing (< 5ms for most formats)

--- a/QuickView/ImageLoader.h
+++ b/QuickView/ImageLoader.h
@@ -334,9 +334,6 @@ public:
 
 
 
-    // [v5.3 DEPRECATED] Use DecodeResult.metadata instead
-    // std::wstring GetLastFormatDetails() const;
-    // int GetLastExifOrientation() const;
 
     // --- NEW: Fast Image Info (Header-Only Parsing) ---
     struct ImageInfo {


### PR DESCRIPTION
🎯 **What:** Removed commented-out implementations and declarations of `GetLastFormatDetails` and `GetLastExifOrientation` in `ImageLoader.cpp` and `ImageLoader.h`.
💡 **Why:** This improves maintainability and readability by removing dead code that has been deprecated since v5.3.
✅ **Verification:** Verified that no active code calls these methods using `grep`. Confirmed the file structure remains intact after removal.
✨ **Result:** Cleaner codebase with less technical debt.

---
*PR created automatically by Jules for task [1724111620791363406](https://jules.google.com/task/1724111620791363406) started by @justnullname*