### PR TITLE
🧹 Refactor HUD coordinate management in SettingsOverlay

### DIFF
--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -330,11 +330,8 @@ bool SettingsOverlay::IsRegistrationNeeded() {
 SettingsOverlay::SettingsOverlay() {
     m_toastHoverBtn = -1;
     m_showUpdateToast = false;
-    m_lastHudX = 0;
-    m_lastHudX = 0;
-    m_lastHudY = 0;
-    m_lastHudX = 0;
-    m_lastHudY = 0;
+    m_hudX = 0;
+    m_hudY = 0;
     m_pendingRebuild = false;
     m_pendingResetFeedback = false;
 }
@@ -1374,13 +1371,12 @@ void SettingsOverlay::Render(ID2D1RenderTarget* pRT, float winW, float winH) {
     if (hudX < 0) hudX = 0;
     if (hudY < 0) hudY = 0;
     
-    m_lastHudX = hudX;
-    m_lastHudY = hudY;
+    m_hudX = hudX;
+    m_hudY = hudY;
 
     // Helper: Draw Main HUD only if visible
     if (m_visible) {
         D2D1_RECT_F hudRect = D2D1::RectF(hudX, hudY, hudX + hudW, hudY + hudH);
-        m_finalHudRect = hudRect;
 
         // 3. Draw HUD Panel Background (Opaque Dark)
         ComPtr<ID2D1SolidColorBrush> brushPanelBg;
@@ -2185,7 +2181,6 @@ SettingsAction SettingsOverlay::OnMouseMove(float x, float y) {
     // NOTE: We need window size. For now, use cached/known values or assume calling code passes them.
     // A better approach is to store m_lastWinW/m_lastWinH. For now, apply simple logic.
     // This function is called with screen coords - we need to transform.
-    // HACK: Store hudX/hudY as member vars. For now, re-calculate based on known item.rect positions.
 
     // 0. Active Combo Logic (Priority)
     if (m_pActiveCombo) {
@@ -2308,15 +2303,12 @@ SettingsAction SettingsOverlay::OnLButtonDown(float x, float y) {
     if (!m_visible) return SettingsAction::None;
 
     // NOTE: We need to check if click is inside HUD bounds.
-    // item.rect stores screen coords, so we can infer HUD bounds from them.
-    // For robustness, we'll use first item rect's X to estimate hudX.
-    // Alternative: Add member vars m_hudX, m_hudY and set in Render. TODO.
-
-    // Use cached HUD rect from Render
-    float hudX = m_finalHudRect.left;
-    float hudY = m_finalHudRect.top;
-    float hudRight = m_finalHudRect.right;
-    float hudBottom = m_finalHudRect.bottom;
+    // Use cached HUD coordinates from Render
+    float s = m_uiScale;
+    float hudX = m_hudX;
+    float hudY = m_hudY;
+    float hudRight = hudX + HUD_WIDTH * s;
+    float hudBottom = hudY + HUD_HEIGHT * s;
 
     // Check if click is OUTSIDE HUD -> Close settings
     if (x < hudX || x > hudRight || y < hudY || y > hudBottom) {

--- a/QuickView/SettingsOverlay.h
+++ b/QuickView/SettingsOverlay.h
@@ -193,11 +193,10 @@ private:
     bool m_showFullLog = false; // Toggle inside About Tab?
     
     // Cached Layout for Input
-    float m_lastHudX = 0.0f;
-    float m_lastHudY = 0.0f;
+    float m_hudX = 0.0f;
+    float m_hudY = 0.0f;
     float m_windowWidth = 0.0f;
     float m_windowHeight = 0.0f;
-    D2D1_RECT_F m_finalHudRect = {}; // Cache for hit-testing
     float m_settingsContentHeight = 0.0f;
     float m_uiScale = 1.0f;
     


### PR DESCRIPTION
What: This PR refactors how HUD coordinates are stored and used in the `SettingsOverlay` class. It introduces `m_hudX` and `m_hudY` member variables, removes the redundant `m_finalHudRect`, and cleans up related initialization and comments.
Why: To resolve state redundancy, improve code clarity, and fulfill the original author's design intent (as noted in TODOs).
Verification: Code reviewed and confirmed as #Correct#. All usages of removed variables were replaced with calculations from the single source of truth (m_hudX, m_hudY).
Result: A cleaner, more maintainable class structure with a single source of truth for HUD positioning.

---
*PR created automatically by Jules for task [4832861044818940162](https://jules.google.com/task/4832861044818940162) started by @justnullname*