### PR TITLE
✨ [fix] Constrain slider hitboxes in Settings menu

### DIFF
--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -2470,8 +2470,12 @@ SettingsAction SettingsOverlay::OnLButtonDown(float x, float y) {
         }
         // Slider
         if (m_pHoverItem->type == OptionType::Slider && m_pHoverItem->pFloatVal) {
-            m_pActiveSlider = m_pHoverItem;
-            OnMouseMove(x, y);
+            float w = 150.0f;
+            float sliderLeft = m_pHoverItem->rect.right - w;
+            if (x >= sliderLeft && x <= m_pHoverItem->rect.right) {
+                m_pActiveSlider = m_pHoverItem;
+                OnMouseMove(x, y);
+            }
             return SettingsAction::RepaintStatic;
         }
         // Segment


### PR DESCRIPTION
🎯 What
Constrained the slider hitbox width to exactly 150 pixels starting from the right side of the item rectangle in `QuickView/SettingsOverlay.cpp`.

⚠️ Risk
Low risk. Only hit testing area in mouse down logic is modified, which limits where dragging can start.

🛡️ Solution
Added logic to explicitly calculate the `sliderLeft` position and compare X coordinate with `sliderLeft` and `rect.right` before allowing `OnMouseMove` drag actions to initialize.

---
*PR created automatically by Jules for task [18363865635547496341](https://jules.google.com/task/18363865635547496341) started by @justnullname*