### PR TITLE
🧹 [Bug Fix] Fix segment button text wrapping and layout in SettingsOverlay

### DIFF
--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -2153,6 +2153,51 @@ void SettingsOverlay::DrawSlider(ID2D1RenderTarget* pRT, const D2D1_RECT_F& rect
     // Ideally right align this text. But OK for now.
 }
 
+std::vector<float> SettingsOverlay::CalculateSegmentWidths(const std::vector<std::wstring>& options, float totalW) {
+    std::vector<float> widths;
+    if (options.empty()) return widths;
+
+    float totalTextW = 0.0f;
+    for (const auto& opt : options) {
+        float textW = 0.0f;
+        if (m_dwriteFactory && m_textFormatItem) {
+            ComPtr<IDWriteTextLayout> layout;
+            if (SUCCEEDED(m_dwriteFactory->CreateTextLayout(
+                opt.c_str(),
+                (UINT32)opt.length(),
+                m_textFormatItem.Get(),
+                2000.0f,
+                50.0f,
+                &layout))) {
+                DWRITE_TEXT_METRICS metrics = {};
+                if (SUCCEEDED(layout->GetMetrics(&metrics))) {
+                    textW = ceilf(metrics.widthIncludingTrailingWhitespace);
+                }
+            }
+        }
+        if (textW <= 0.0f) textW = (float)opt.length() * 8.0f * m_uiScale;
+        widths.push_back(textW);
+        totalTextW += textW;
+    }
+
+    float remainingW = totalW - totalTextW;
+    if (remainingW > 0.0f) {
+        // Distribute remaining space equally as padding
+        float paddingPerItem = remainingW / options.size();
+        for (auto& w : widths) {
+            w += paddingPerItem;
+        }
+    } else {
+        // If text is too wide, scale proportionally
+        float scale = totalW / totalTextW;
+        for (auto& w : widths) {
+            w *= scale;
+        }
+    }
+
+    return widths;
+}
+
 void SettingsOverlay::DrawSegment(ID2D1RenderTarget* pRT, const D2D1_RECT_F& rect, int selectedIdx, const std::vector<std::wstring>& options) {
     if (options.empty()) return;
 
@@ -2160,29 +2205,33 @@ void SettingsOverlay::DrawSegment(ID2D1RenderTarget* pRT, const D2D1_RECT_F& rec
     // Actually, stick to a fixed width or fill control area?
     // Let's use Rect provided (Control Area).
     float totalW = rect.right - rect.left;
-    float itemW = totalW / options.size();
+    std::vector<float> itemWidths = CalculateSegmentWidths(options, totalW);
     
     // Background Container
     pRT->FillRoundedRectangle(D2D1::RoundedRect(rect, 4.0f, 4.0f), m_brushControlBg.Get());
 
     // Selected Highlight
     if (selectedIdx >= 0 && selectedIdx < (int)options.size()) {
-        float selX = rect.left + itemW * selectedIdx;
-        D2D1_RECT_F selRect = D2D1::RectF(selX + 2, rect.top + 2, selX + itemW - 2, rect.bottom - 2);
+        float selX = rect.left;
+        for (int i = 0; i < selectedIdx; ++i) {
+            selX += itemWidths[i];
+        }
+        D2D1_RECT_F selRect = D2D1::RectF(selX + 2, rect.top + 2, selX + itemWidths[selectedIdx] - 2, rect.bottom - 2);
         pRT->FillRoundedRectangle(D2D1::RoundedRect(selRect, 3.0f, 3.0f), m_brushAccent.Get());
     }
 
     // Dividers/Text
     m_textFormatItem->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER); // Switch to Center
 
+    float currentX = rect.left;
     for (size_t i = 0; i < options.size(); i++) {
-        float tx = rect.left + itemW * i;
-        D2D1_RECT_F tRect = D2D1::RectF(tx, rect.top, tx + itemW, rect.bottom);
+        D2D1_RECT_F tRect = D2D1::RectF(currentX, rect.top, currentX + itemWidths[i], rect.bottom);
         
         bool isSel = ((int)i == selectedIdx);
         // Draw Divider (if not first and not selected/adjacent) - simplified: just text
         
         pRT->DrawTextW(options[i].c_str(), (UINT32)options[i].length(), m_textFormatItem.Get(), tRect, m_brushText.Get(), D2D1_DRAW_TEXT_OPTIONS_NONE); 
+        currentX += itemWidths[i];
     }
     m_textFormatItem->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING); // Restore Default
 }
@@ -2479,9 +2528,17 @@ SettingsAction SettingsOverlay::OnLButtonDown(float x, float y) {
              float controlX = m_pHoverItem->rect.left + 260.0f;
              float controlW = m_pHoverItem->rect.right - controlX;
              
-             if (x >= controlX) {
-                 float itemW = controlW / m_pHoverItem->options.size();
-                 int idx = (int)((x - controlX) / itemW);
+             if (x >= controlX && x <= controlX + controlW) {
+                 std::vector<float> itemWidths = CalculateSegmentWidths(m_pHoverItem->options, controlW);
+                 float currentX = controlX;
+                 int idx = -1;
+                 for (size_t i = 0; i < itemWidths.size(); ++i) {
+                     if (x >= currentX && x < currentX + itemWidths[i]) {
+                         idx = (int)i;
+                         break;
+                     }
+                     currentX += itemWidths[i];
+                 }
                  if (idx >= 0 && idx < (int)m_pHoverItem->options.size()) {
                      *m_pHoverItem->pIntVal = idx;
                      if (m_pHoverItem->onChange) m_pHoverItem->onChange();

--- a/QuickView/SettingsOverlay.h
+++ b/QuickView/SettingsOverlay.h
@@ -123,6 +123,7 @@ private:
     // Draw Widgets
     void DrawToggle(ID2D1RenderTarget* pRT, const D2D1_RECT_F& rect, bool isOn, bool isHovered);
     void DrawSlider(ID2D1RenderTarget* pRT, const D2D1_RECT_F& rect, float val, float minV, float maxV, bool isHovered);
+    std::vector<float> CalculateSegmentWidths(const std::vector<std::wstring>& options, float totalW);
     void DrawSegment(ID2D1RenderTarget* pRT, const D2D1_RECT_F& rect, int selectedIdx, const std::vector<std::wstring>& options);
     void DrawComboBox(ID2D1RenderTarget* pRT, const D2D1_RECT_F& rect, int selectedIdx, const std::vector<std::wstring>& options, bool isOpen);
     void DrawComboDropdown(ID2D1RenderTarget* pRT); // Draws the floating list


### PR DESCRIPTION
**What**
Implemented dynamic width calculation for segmented toggle buttons (`OptionType::Segment`) in `SettingsOverlay` using DirectWrite text measurements.

**Why**
Some translated text strings (e.g., "Balanced") were too long for the fixed-width equal division layout, causing them to exceed their bounds and wrap to a new line, breaking the UI.

**Verification**
Created a standalone test program using mock data to verify the text width distribution and scaling math. Verified the changes in the actual code logic for drawing and mouse click hit-testing. 

**Result**
Segment buttons now size themselves based on their actual text content, resolving text clipping/wrapping issues for all supported languages.

---
*PR created automatically by Jules for task [12862509831197608603](https://jules.google.com/task/12862509831197608603) started by @justnullname*