### PR TITLE
feat: add context menu to gallery thumbnails

### DIFF
--- a/QuickView/AppStrings.cpp
+++ b/QuickView/AppStrings.cpp
@@ -98,6 +98,8 @@ namespace AppStrings {
     const wchar_t* Context_Settings = nullptr;
     const wchar_t* Context_About = nullptr;
     const wchar_t* Context_CompareMode = nullptr; // New
+    const wchar_t* Context_GalleryOpenCompare = nullptr;
+    const wchar_t* Context_GalleryOpenNewWindow = nullptr;
     const wchar_t* Context_Exit = nullptr;
 
     const wchar_t* HUD_Label_High = nullptr;
@@ -470,6 +472,8 @@ namespace AppStrings {
         static constexpr const wchar_t* Context_Settings = L"Settings...";
         static constexpr const wchar_t* Context_About = L"About QuickView";
         static constexpr const wchar_t* Context_CompareMode = L"Compare Mode\tC";
+        static constexpr const wchar_t* Context_GalleryOpenCompare = L"Open in Compare Mode";
+        static constexpr const wchar_t* Context_GalleryOpenNewWindow = L"Open in New Window";
         static constexpr const wchar_t* Context_Exit = L"Exit\tMButton/Esc";
 
         static constexpr const wchar_t* Settings_Tab_Visuals = L"Visuals";
@@ -847,6 +851,8 @@ namespace AppStrings {
         static constexpr const wchar_t* Context_Settings = L"设置...";
         static constexpr const wchar_t* Context_About = L"关于 QuickView";
         static constexpr const wchar_t* Context_CompareMode = L"对比模式\tC";
+        static constexpr const wchar_t* Context_GalleryOpenCompare = L"在对比模式中打开";
+        static constexpr const wchar_t* Context_GalleryOpenNewWindow = L"在新窗口中打开";
         static constexpr const wchar_t* Context_Exit = L"退出\tMButton/Esc";
 
         // Messages
@@ -1086,6 +1092,8 @@ namespace AppStrings {
         static constexpr const wchar_t* Context_Settings = L"設定...";
         static constexpr const wchar_t* Context_About = L"關於 QuickView";
         static constexpr const wchar_t* Context_CompareMode = L"對比模式\tC";
+        static constexpr const wchar_t* Context_GalleryOpenCompare = L"在對比模式中打開";
+        static constexpr const wchar_t* Context_GalleryOpenNewWindow = L"在新視窗中打開";
         static constexpr const wchar_t* Context_Exit = L"結束\tMButton/Esc";
         static constexpr const wchar_t* Settings_Tab_Visuals = L"外觀";
         static constexpr const wchar_t* Settings_Tab_Controls = L"操作";
@@ -1379,6 +1387,8 @@ namespace AppStrings {
         static constexpr const wchar_t* Context_Settings = L"設定...";
         static constexpr const wchar_t* Context_About = L"QuickViewについて";
         static constexpr const wchar_t* Context_CompareMode = L"比較モード\tC";
+        static constexpr const wchar_t* Context_GalleryOpenCompare = L"比較モードで開く";
+        static constexpr const wchar_t* Context_GalleryOpenNewWindow = L"新しいウィンドウで開く";
         static constexpr const wchar_t* Context_Exit = L"終了\tMButton/Esc";
         static constexpr const wchar_t* Settings_Tab_Visuals = L"外観";
         static constexpr const wchar_t* Settings_Tab_Controls = L"操作";
@@ -1672,6 +1682,8 @@ namespace AppStrings {
         static constexpr const wchar_t* Context_Settings = L"Настройки...";
         static constexpr const wchar_t* Context_About = L"О QuickView";
         static constexpr const wchar_t* Context_CompareMode = L"Режим сравнения\tC";
+        static constexpr const wchar_t* Context_GalleryOpenCompare = L"Открыть в режиме сравнения";
+        static constexpr const wchar_t* Context_GalleryOpenNewWindow = L"Открыть в новом окне";
         static constexpr const wchar_t* Context_Exit = L"Выход\tMButton/Esc";
         static constexpr const wchar_t* Settings_Tab_Visuals = L"Внешний вид";
         static constexpr const wchar_t* Settings_Tab_Controls = L"Управление";
@@ -1965,6 +1977,8 @@ namespace AppStrings {
         static constexpr const wchar_t* Context_Settings = L"Einstellungen...";
         static constexpr const wchar_t* Context_About = L"Über QuickView";
         static constexpr const wchar_t* Context_CompareMode = L"Vergleichsmodus\tC";
+        static constexpr const wchar_t* Context_GalleryOpenCompare = L"Im Vergleichsmodus öffnen";
+        static constexpr const wchar_t* Context_GalleryOpenNewWindow = L"In neuem Fenster öffnen";
         static constexpr const wchar_t* Context_Exit = L"Beenden\tMButton/Esc";
         static constexpr const wchar_t* Settings_Tab_Visuals = L"Aussehen";
         static constexpr const wchar_t* Settings_Tab_Controls = L"Steuerung";
@@ -2258,6 +2272,8 @@ namespace AppStrings {
         static constexpr const wchar_t* Context_Settings = L"Configuración...";
         static constexpr const wchar_t* Context_About = L"Acerca de QuickView";
         static constexpr const wchar_t* Context_CompareMode = L"Modo comparación\tC";
+        static constexpr const wchar_t* Context_GalleryOpenCompare = L"Abrir en modo de comparación";
+        static constexpr const wchar_t* Context_GalleryOpenNewWindow = L"Abrir en una ventana nueva";
         static constexpr const wchar_t* Context_Exit = L"Salir\tMButton/Esc";
         static constexpr const wchar_t* Settings_Tab_Visuals = L"Apariencia";
         static constexpr const wchar_t* Settings_Tab_Controls = L"Controles";
@@ -2510,6 +2526,8 @@ namespace AppStrings {
         Context_Settings = T::Context_Settings;
         Context_About = T::Context_About;
         Context_CompareMode = T::Context_CompareMode;
+        Context_GalleryOpenCompare = T::Context_GalleryOpenCompare;
+        Context_GalleryOpenNewWindow = T::Context_GalleryOpenNewWindow;
         Context_Exit = T::Context_Exit;
 
         Message_SaveErrorTitle = T::Message_SaveErrorTitle;

--- a/QuickView/AppStrings.h
+++ b/QuickView/AppStrings.h
@@ -82,6 +82,8 @@ namespace AppStrings {
     extern const wchar_t* Context_Settings;
     extern const wchar_t* Context_About;
     extern const wchar_t* Context_CompareMode; // New
+    extern const wchar_t* Context_GalleryOpenCompare;
+    extern const wchar_t* Context_GalleryOpenNewWindow;
     extern const wchar_t* Context_Exit;
     
     // Messages

--- a/QuickView/ContextMenu.cpp
+++ b/QuickView/ContextMenu.cpp
@@ -107,3 +107,16 @@ void ShowContextMenu(HWND hwnd, POINT pt, bool hasImage, bool needsExtensionFix,
     
     DestroyMenu(hMenu);
 }
+
+void ShowGalleryContextMenu(HWND hwnd, POINT pt) {
+    HMENU hMenu = CreatePopupMenu();
+    if (!hMenu) return;
+
+    AppendMenuW(hMenu, MF_STRING, IDM_GALLERY_OPEN_COMPARE, AppStrings::Context_GalleryOpenCompare);
+    AppendMenuW(hMenu, MF_STRING, IDM_GALLERY_OPEN_NEW_WINDOW, AppStrings::Context_GalleryOpenNewWindow);
+
+    TrackPopupMenu(hMenu, TPM_RIGHTBUTTON | TPM_LEFTALIGN | TPM_TOPALIGN,
+                   pt.x, pt.y, 0, hwnd, nullptr);
+
+    DestroyMenu(hMenu);
+}

--- a/QuickView/ContextMenu.h
+++ b/QuickView/ContextMenu.h
@@ -40,6 +40,10 @@ enum ContextMenuCommand : UINT {
     IDM_TOGGLE_SPAN, // [New] Video Wall Mode
     IDM_COMPARE_MODE, // Toggle Compare Mode
 
+    // [Gallery] Group
+    IDM_GALLERY_OPEN_COMPARE,
+    IDM_GALLERY_OPEN_NEW_WINDOW,
+
 
     // [Transform] Group
     IDM_ROTATE_CW,
@@ -71,3 +75,5 @@ enum ContextMenuCommand : UINT {
 /// <param name="renderRaw">Whether Render RAW mode is active</param>
 /// <param name="isRawFile">Whether current file is RAW format</param>
 void ShowContextMenu(HWND hwnd, POINT pt, bool hasImage, bool needsExtensionFix, bool isWindowLocked, bool showInfoPanel, bool infoPanelExpanded, bool alwaysOnTop, bool renderRaw, bool isRawFile, bool isFullscreen, bool isCrossMonitor, bool isCompareMode, bool isPixelArtMode);
+
+void ShowGalleryContextMenu(HWND hwnd, POINT pt);

--- a/QuickView/GalleryOverlay.cpp
+++ b/QuickView/GalleryOverlay.cpp
@@ -335,6 +335,11 @@ bool GalleryOverlay::OnMouseMove(int x, int y) {
     return m_hoverIndex != oldHover;  // Only repaint if hover changed
 }
 
+int GalleryOverlay::HitTestClient(int x, int y) {
+    if (!m_isVisible) return -1;
+    return HitTest((float)x, (float)y + m_scrollTop);
+}
+
 int GalleryOverlay::HitTest(float x, float y) {
     // Inverse of layout
     // y = PADDING + r * (h + GAP)

--- a/QuickView/GalleryOverlay.h
+++ b/QuickView/GalleryOverlay.h
@@ -31,6 +31,9 @@ public:
     // Returns selected index when closed via Enter/Click
     int GetSelectedIndex() const { return m_selectedIndex; }
     
+    // Calculate thumbnail index from client coordinates
+    int HitTestClient(int x, int y);
+
     // Animation tick (fade in)
     void Update(float deltaTime);
 

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -260,6 +260,7 @@ static float GetMinWindowWidth() {
 
 static ComPtr<IDWriteTextFormat> g_pPanelTextFormat;
 static D2D1_RECT_F g_gpsLinkRect = {}; 
+int g_galleryContextMenuIndex = -1;
 static D2D1_RECT_F g_gpsCoordRect = {};  // GPS Coordinates click area
 static D2D1_RECT_F g_filenameRect = {};  // Filename click area
 static D2D1_RECT_F g_panelToggleRect = {}; // Expand/Collapse Button Rect
@@ -7162,6 +7163,15 @@ SKIP_EDGE_NAV:;
         POINT pt = ptClient;
         ClientToScreen(hwnd, &pt);
 
+        if (g_gallery.IsVisible()) {
+            int idx = g_gallery.HitTestClient(ptClient.x, ptClient.y);
+            if (idx >= 0) {
+                g_galleryContextMenuIndex = idx;
+                ShowGalleryContextMenu(hwnd, pt);
+            }
+            return 0;
+        }
+
         if (IsCompareModeActive()) {
             g_compare.contextPane = HitTestComparePane(hwnd, ptClient);
             g_compare.activePane = g_compare.contextPane;
@@ -7212,6 +7222,37 @@ SKIP_EDGE_NAV:;
         const std::wstring& contextPath = contextLeft ? g_compare.left.path : g_imagePath;
         const CImageLoader::ImageMetadata& contextMeta = contextLeft ? g_compare.left.metadata : g_currentMetadata;
         switch (cmdId) {
+        case IDM_GALLERY_OPEN_COMPARE: {
+            if (g_galleryContextMenuIndex >= 0 && g_galleryContextMenuIndex < (int)g_navigator.Count()) {
+                std::wstring path = g_navigator.GetFile(g_galleryContextMenuIndex);
+                g_gallery.Close();
+                RestoreOverlayWindowState(hwnd);
+                if (!IsCompareModeActive()) {
+                    EnterCompareMode(hwnd);
+                }
+                if (IsCompareModeActive()) {
+                    if (LoadImageIntoCompareLeftSlot(hwnd, path)) {
+                        g_compare.activePane = ComparePane::Left;
+                        MarkCompareDirty();
+                    }
+                }
+                RequestRepaint(PaintLayer::All);
+            }
+            break;
+        }
+
+        case IDM_GALLERY_OPEN_NEW_WINDOW: {
+            if (g_galleryContextMenuIndex >= 0 && g_galleryContextMenuIndex < (int)g_navigator.Count()) {
+                std::wstring path = g_navigator.GetFile(g_galleryContextMenuIndex);
+                wchar_t exePath[MAX_PATH];
+                if (GetModuleFileNameW(nullptr, exePath, MAX_PATH)) {
+                    // Enclose path in quotes
+                    std::wstring args = L"\"" + path + L"\"";
+                    ShellExecuteW(nullptr, L"open", exePath, args.c_str(), nullptr, SW_SHOWNORMAL);
+                }
+            }
+            break;
+        }
         case IDM_OPEN: {
             if (!CheckUnsavedChanges(hwnd)) break;
             OPENFILENAMEW ofn = {};


### PR DESCRIPTION
Implemented a specific context menu for the gallery view.\n\nChanges include:\n1. Added `HitTestClient` in `GalleryOverlay` to determine the thumbnail index at cursor coordinates.\n2. In `main.cpp`'s `WM_RBUTTONUP` handler, added logic to detect if the gallery is visible and trigger a custom gallery context menu.\n3. Handled the `WM_COMMAND` IDs for `IDM_GALLERY_OPEN_COMPARE` (opens the selected image in compare mode) and `IDM_GALLERY_OPEN_NEW_WINDOW` (launches a new instance of QuickView for the selected image).\n4. Updated string resources across all 7 supported languages.

---
*PR created automatically by Jules for task [6966794401977798579](https://jules.google.com/task/6966794401977798579) started by @justnullname*