### PR TITLE
Fix Compare mode Info HUD tooltip responsiveness and stickiness

### DIFF
--- a/QuickView/UIRenderer.cpp
+++ b/QuickView/UIRenderer.cpp
@@ -132,8 +132,17 @@ HitTestResult UIRenderer::HitTest(float x, float y) {
 
         if (PointInRect(x, y, m_lastHUDRect)) {
             result.type = UIHitResult::InfoRow; 
-            result.rowIndex = -2; 
-            m_hoverRowIndex = -2; // Set hover state here for prompt tooltip
+            result.rowIndex = -2; // Default for empty HUD space
+
+            // Check individual rows to trigger repaint on hover change
+            for (size_t i = 0; i < m_compareRowRects.size(); ++i) {
+                if (PointInRect(x, y, m_compareRowRects[i])) {
+                    result.rowIndex = -100 - (int)i; // Unique ID for Compare HUD rows
+                    break;
+                }
+            }
+
+            m_hoverRowIndex = result.rowIndex; // Set hover state here for prompt tooltip
             return result;
         }
     }
@@ -1962,7 +1971,7 @@ void UIRenderer::DrawGridTooltip(ID2D1DeviceContext* dc) {
     if (m_hoverRowIndex >= 0 && m_hoverRowIndex < (int)m_infoGrid.size()) {
         row = m_infoGrid[m_hoverRowIndex];
         if (!row.isTruncated || row.fullText.empty()) return;
-    } else if (m_hoverRowIndex == -2) {
+    } else if (m_hoverRowIndex <= -2) { // Changed to <= -2 to pick up unique IDs like -100
         row = m_hoverInfoRow;
         if (row.fullText.empty()) return;
     } else {
@@ -2476,6 +2485,9 @@ void UIRenderer::DrawCompareInfoHUD(ID2D1DeviceContext* dc) {
 
     y += headerH;
 
+    m_compareRowRects.clear();
+    m_hoverInfoRow = InfoRow{}; // Clear previous hover state to prevent sticky tooltips
+
     for (const auto& group : hudGroups) {
         // Group visibility check taking identical hiding into account
         bool groupHasData = false;
@@ -2517,13 +2529,14 @@ void UIRenderer::DrawCompareInfoHUD(ID2D1DeviceContext* dc) {
             }
 
             D2D1_RECT_F rowRect = D2D1::RectF(panelX + 4, y, panelX + panelW - 4, y + rowH);
+            m_compareRowRects.push_back(rowRect);
+
             if (PointInRect((float)m_lastMousePos.x, (float)m_lastMousePos.y, rowRect)) {
                 ComPtr<ID2D1SolidColorBrush> brushHover;
                 dc->CreateSolidColorBrush(D2D1::ColorF(1, 1, 1, 0.05f), &brushHover);
                 dc->FillRectangle(rowRect, brushHover.Get());
                 
-                // Track hover row consistently with HitTest
-                m_hoverRowIndex = -2; 
+                // Rely on HitTest to set m_hoverRowIndex
                 m_hoverInfoRow = lRow ? *lRow : (rRow ? *rRow : InfoRow{});
                 
                 // If this is the File row, ensure tooltip shows full filename
@@ -2694,6 +2707,6 @@ void UIRenderer::DrawCompareInfoHUD(ID2D1DeviceContext* dc) {
 
     // Reset hover if outside HUD
     if (!PointInRect((float)m_lastMousePos.x, (float)m_lastMousePos.y, m_lastHUDRect)) {
-        if (m_hoverRowIndex == -2) m_hoverRowIndex = -1;
+        if (m_hoverRowIndex <= -2) m_hoverRowIndex = -1;
     }
 }

--- a/QuickView/UIRenderer.h
+++ b/QuickView/UIRenderer.h
@@ -200,6 +200,7 @@ private:
     D2D1_RECT_F m_gpsCoordRect = {};
     D2D1_RECT_F m_gpsLinkRect = {};
     D2D1_RECT_F m_lastHUDRect = {}; // Track HUD area for hit testing
+    std::vector<D2D1_RECT_F> m_compareRowRects; // Track individual row rects in Compare HUD
     D2D1_RECT_F m_hudToggleLiteRect = {}; // Track HUD lite mode icon area
     D2D1_RECT_F m_hudToggleExpandRect = {}; // Track HUD expand mode icon area
     


### PR DESCRIPTION
Fixes an issue in the Compare mode Info HUD where tooltips were sluggish to appear (often requiring a click) and remained visible when hovering over empty space. The fix introduces proper hit-testing rects for individual HUD rows and assigns them unique IDs, allowing `WM_MOUSEMOVE` to detect state changes and immediately trigger a repaint. It also clears the hover state before drawing to prevent sticky tooltips.

---
*PR created automatically by Jules for task [6446442504367955317](https://jules.google.com/task/6446442504367955317) started by @justnullname*