### PR TITLE
Fix vertical text alignment in Compare HUD

### DIFF
--- a/QuickView/UIRenderer.cpp
+++ b/QuickView/UIRenderer.cpp
@@ -448,6 +448,9 @@ void UIRenderer::EnsureTextFormats() {
             DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
             12.0f, L"en-us", &m_debugFormat
         );
+        if (m_debugFormat) {
+            m_debugFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+        }
     }
     
     if (!m_iconFormat) {
@@ -489,6 +492,7 @@ void UIRenderer::EnsureTextFormats() {
         );
         if (m_panelFormat) {
             m_panelFormat->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP);
+            m_panelFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
         }
     }
 }


### PR DESCRIPTION
Fix vertical text alignment in Compare HUD

Update the initialization of m_debugFormat and m_panelFormat in UIRenderer to use
DWRITE_PARAGRAPH_ALIGNMENT_CENTER. This ensures that the text within the
information rows in Compare Mode (both Lite and Full views) is vertically
centered within its bounding box, resolving the issue where text stuck to the top
edge during hover highlights.

---
*PR created automatically by Jules for task [8990436489985629182](https://jules.google.com/task/8990436489985629182) started by @justnullname*