### PR TITLE
Implement hover effects for link buttons in Settings Overlay

### DIFF
--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -342,6 +342,7 @@ bool SettingsOverlay::IsRegistrationNeeded() {
 }
 
 SettingsOverlay::SettingsOverlay() {
+    m_lastMousePos = { -1.0f, -1.0f };
     m_toastHoverBtn = -1;
     m_showUpdateToast = false;
     m_hudX = 0;
@@ -1801,16 +1802,11 @@ void SettingsOverlay::Render(ID2D1DeviceContext* pRT, float winW, float winH) {
                 // 3 Columns: GitHub, Issues, Hotkeys
                 LinkRects r = GetLinkButtonRects(D2D1::RectF(contentX, contentY, contentX + contentW, contentY + 40));
                 
-                // Pass mouse pos logic?
-                // We'll simplisticly check if ANY sub-rect contains mouse in OnMouseMove but here we just render.
-                // We need to know mouse pos to render hover effect.
-                // Hack: We don't have mouse pos here easily unless stored.
-                // User ASKED for hover effect. 
-                // We can cache sub-hover index in OnMouseMove in "m_hoverLinkIndex" member if we add it.
-                // Or easier: Just draw outlined always, good enough?
-                // No, "增加鼠标经过效果".
-                // TODO: Implement `m_lastMousePos` in `OnMouseMove` and use it here.
-                // For now, assume we implement that next step or use simple outline.
+                // Update hover state for links using stored mouse position
+                m_hoverLinkIndex = -1;
+                if (m_lastMousePos.x >= r.github.left && m_lastMousePos.x <= r.github.right && m_lastMousePos.y >= r.github.top && m_lastMousePos.y <= r.github.bottom) m_hoverLinkIndex = 0;
+                else if (m_lastMousePos.x >= r.issues.left && m_lastMousePos.x <= r.issues.right && m_lastMousePos.y >= r.issues.top && m_lastMousePos.y <= r.issues.bottom) m_hoverLinkIndex = 1;
+                else if (m_lastMousePos.x >= r.keys.left && m_lastMousePos.x <= r.keys.right && m_lastMousePos.y >= r.keys.top && m_lastMousePos.y <= r.keys.bottom) m_hoverLinkIndex = 2;
                 
                 // GitHub
                 {
@@ -2439,6 +2435,7 @@ void SettingsOverlay::DrawSegment(ID2D1DeviceContext* pRT, const D2D1_RECT_F& re
 // ----------------------------------------------------------------------------
 
 SettingsAction SettingsOverlay::OnMouseMove(float x, float y) {
+    m_lastMousePos = D2D1::Point2F(x, y);
     // Toast Hit Test (Priority - Even if not visible)
     if (m_showUpdateToast) {
         m_toastHoverBtn = -1;

--- a/QuickView/SettingsOverlay.h
+++ b/QuickView/SettingsOverlay.h
@@ -109,6 +109,7 @@ public:
     static bool IsRegistrationNeeded();
 
 private:
+    D2D1_POINT_2F m_lastMousePos;
     void CreateResources(ID2D1DeviceContext* pRT);
     
     void DrawToggle(ID2D1DeviceContext* pRT, const D2D1_RECT_F& rect, bool isOn, bool isHovered);


### PR DESCRIPTION
This change adds `m_lastMousePos` to track the mouse position within the Settings Overlay. This position is updated during `OnMouseMove` and used during `Render` to perform hit-testing on the "About" link buttons (GitHub, Issues, Help). This enables the requested hover background effect for these buttons, improving the visual feedback of the UI.

---
*PR created automatically by Jules for task [13846702975651442414](https://jules.google.com/task/13846702975651442414) started by @justnullname*