### PR TITLE
🧹 Add missing pool stats to DebugStats

### DIFF
--- a/QuickView/ImageEngine.cpp
+++ b/QuickView/ImageEngine.cpp
@@ -727,7 +727,11 @@ ImageEngine::DebugStats ImageEngine::GetDebugStats() const {
     s.heavyPendingCount = poolStats.pendingJobs;
     s.heavyDecodeTimeMs = poolStats.lastDecodeTimeMs; 
     s.heavyLastImageId = poolStats.lastDecodeId; // [HUD Fix]
-    // TODO: Add pool stats to DebugStats (busyWorkers, standbyWorkers, etc.)
+    s.heavyBusyWorkers = poolStats.busyWorkers;
+    s.heavyStandbyWorkers = poolStats.standbyWorkers;
+    s.heavyTotalWorkers = poolStats.totalWorkers;
+    s.heavyActiveWorkers = poolStats.activeWorkers;
+    s.heavyTileJobs = poolStats.activeTileJobs;
     
     // Memory
     s.memoryUsed = m_pool.GetUsedMemory();

--- a/QuickView/ImageEngine.h
+++ b/QuickView/ImageEngine.h
@@ -247,6 +247,11 @@ public:
 
         std::wstring loaderName;   // Last used decoder name
         int heavyPendingCount = 0; // New: Heavy Lane Pending Count
+        int heavyBusyWorkers = 0;
+        int heavyStandbyWorkers = 0;
+        int heavyTotalWorkers = 0;
+        int heavyActiveWorkers = 0;
+        int heavyTileJobs = 0;
         
         // Phase 4: HUD Enhancements
         CacheTopology topology;    // Cache strip [-2..+2]


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Added missing worker pool metrics to the `DebugStats` struct in `ImageEngine.h`.
- Populated these new fields in `ImageEngine::GetDebugStats` by mapping them from the `HeavyLanePool::PoolStats`.
- Removed the `TODO` comment in `ImageEngine.cpp`.

💡 **Why:** How this improves maintainability
- Fulfills a pending `TODO` and ensures that the legacy `DebugStats` API provides a more complete view of the thread pool's state, matching the metrics available in the newer `TelemetrySnapshot` system. This improves the utility of the HUD for debugging performance issues related to worker concurrency and tile decoding.

✅ **Verification:** How you confirmed the change is safe
- Verified the struct definition in `ImageEngine.h` and the assignment logic in `ImageEngine.cpp` using `read_file` and `sed`.
- Confirmed that the field names in `HeavyLanePool::PoolStats` (busyWorkers, standbyWorkers, totalWorkers, activeWorkers, activeTileJobs) were correctly used.
- Performed a code review which rated the change as #Correct#.

✨ **Result:** The improvement achieved
- The `DebugStats` structure now includes real-time metrics for busy, standby, active, and total workers, as well as the number of active tile jobs, providing better visibility into the engine's background processing state.

---
*PR created automatically by Jules for task [15238217894713112816](https://jules.google.com/task/15238217894713112816) started by @justnullname*