### PR TITLE
Add pool stats to DebugStats

### DIFF
--- a/QuickView/ImageEngine.cpp
+++ b/QuickView/ImageEngine.cpp
@@ -720,7 +720,11 @@ ImageEngine::DebugStats ImageEngine::GetDebugStats() const {
     s.heavyPendingCount = poolStats.pendingJobs;
     s.heavyDecodeTimeMs = poolStats.lastDecodeTimeMs; 
     s.heavyLastImageId = poolStats.lastDecodeId; // [HUD Fix]
-    // TODO: Add pool stats to DebugStats (busyWorkers, standbyWorkers, etc.)
+    s.heavyBusyWorkers = poolStats.busyWorkers;
+    s.heavyStandbyWorkers = poolStats.standbyWorkers;
+    s.heavyTotalWorkers = poolStats.totalWorkers;
+    s.heavyActiveWorkers = poolStats.activeWorkers;
+    s.heavyTileJobs = poolStats.activeTileJobs;
     
     // Memory
     s.memoryUsed = m_pool.GetUsedMemory();

--- a/QuickView/ImageEngine.h
+++ b/QuickView/ImageEngine.h
@@ -246,7 +246,12 @@ public:
 
         std::wstring loaderName;   // Last used decoder name
         int heavyPendingCount = 0; // New: Heavy Lane Pending Count
-        
+        int heavyBusyWorkers = 0;
+        int heavyStandbyWorkers = 0;
+        int heavyTotalWorkers = 0;
+        int heavyActiveWorkers = 0;
+        int heavyTileJobs = 0;
+
         // Phase 4: HUD Enhancements
         CacheTopology topology;    // Cache strip [-2..+2]
         size_t cacheMemoryUsed = 0; // Cache memory usage


### PR DESCRIPTION
Exposed additional worker pool statistics from `HeavyLanePool` into the `ImageEngine::DebugStats` structure. This involves adding fields for busy, standby, active, and total workers, as well as the count of active tile jobs, and populating them during debug stats retrieval.

---
*PR created automatically by Jules for task [8984240922925091414](https://jules.google.com/task/8984240922925091414) started by @justnullname*