### PR TITLE
🧹 remove commented out if block in main.cpp

### DIFF
--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -9623,9 +9623,6 @@ void StartNavigation(HWND hwnd, std::wstring path, bool showOSD, QuickView::Brow
     // [Fix] Ensure RAW button visibility is updated immediately on navigation
     g_toolbar.SetRawState(IsRawFile(path), g_runtime.ForceRawDecode);
     
-    // Level 0 Feedback: Immediate OSD before any decode starts
-    // Level 0 Feedback: Immediate OSD removed as per user request
-    // if (showOSD) { ... }
     PostMessage(hwnd, WM_SETCURSOR, (WPARAM)hwnd, MAKELPARAM(HTCLIENT, WM_MOUSEMOVE));
     
 // Phase 2 Kick: queue-drop debounce (Titan only)


### PR DESCRIPTION
🎯 **What:** Removed a legacy commented-out `if (showOSD)` block and its associated feedback comments in `QuickView/main.cpp`.
💡 **Why:** This code was dead and redundant, as the "Level 0 Feedback" OSD had been explicitly removed per user request. Removing it improves the readability and maintainability of the `StartNavigation` function.
✅ **Verification:** Manually verified the file content after deletion to ensure no functional code was affected. Code review confirmed the change is safe and cosmetic only.
✨ **Result:** Cleaner codebase with less dead code in the critical navigation path.

---
*PR created automatically by Jules for task [15452667751170008613](https://jules.google.com/task/15452667751170008613) started by @justnullname*