### PR TITLE
🔒 Fix Unvalidated Integer Overflow in Bitmap Allocation

### DIFF
--- a/QuickView/ImageLoader.cpp
+++ b/QuickView/ImageLoader.cpp
@@ -3332,10 +3332,10 @@ static void PopulateMetadataFromEasyExif(const easyexif::EXIFInfo& exif, CImageL
                             if (WebPAnimDecoderGetNext(dec, &frameBuf, &timestamp) && frameBuf) {
                                 int w = (int)animInfo.canvas_width;
                                 int h = (int)animInfo.canvas_height;
-                                int stride = CalculateSIMDAlignedStride(w, 4);
-                                size_t bufSize = (size_t)stride * h;
+                                int stride = SafeCalculateStride(w, 4);
+                                size_t bufSize = SafeCalculateBufferSize(stride, h);
 
-                                uint8_t* pixels = ctx.allocator(bufSize);
+                                uint8_t* pixels = (stride > 0 && bufSize > 0) ? ctx.allocator(bufSize) : nullptr;
                                 if (!pixels) { WebPAnimDecoderDelete(dec); return E_OUTOFMEMORY; }
 
                                 // Copy with periodic cancel check
@@ -3415,10 +3415,10 @@ static void PopulateMetadataFromEasyExif(const easyexif::EXIFInfo& exif, CImageL
                      finalH = config.options.scaled_height;
                 }
 
-                int stride = CalculateSIMDAlignedStride(finalW, 4);
-                size_t bufSize = (size_t)stride * finalH;
+                int stride = SafeCalculateStride(finalW, 4);
+                size_t bufSize = SafeCalculateBufferSize(stride, finalH);
 
-                uint8_t* pixels = ctx.allocator(bufSize);
+                uint8_t* pixels = (stride > 0 && bufSize > 0) ? ctx.allocator(bufSize) : nullptr;
                 if (!pixels) return E_OUTOFMEMORY;
 
                 // Direct Decode Setup
@@ -4494,10 +4494,10 @@ namespace QuickView {
 
                 int w = cinfo.output_width;
                 int h = cinfo.output_height;
-                int stride = CalculateSIMDAlignedStride(w, 4);
-                size_t totalSize = (size_t)stride * h;
+                int stride = SafeCalculateStride(w, 4);
+                size_t totalSize = SafeCalculateBufferSize(stride, h);
 
-                uint8_t* pixels = ctx.allocator(totalSize);
+                uint8_t* pixels = (stride > 0 && totalSize > 0) ? ctx.allocator(totalSize) : nullptr;
                 if (!pixels) {
                     jpeg_abort_decompress(&cinfo);
                     jpeg_destroy_decompress(&cinfo);
@@ -5247,8 +5247,9 @@ namespace QuickView {
 
                     const int width = rgb.width;
                     const int height = rgb.height;
-                    const int stride = CalculateSIMDAlignedStride(width, 16);
-                    uint8_t* pixels = ctx.allocator(static_cast<size_t>(stride) * height);
+                    const int stride = SafeCalculateStride(width, 16);
+                    const size_t totalSize = SafeCalculateBufferSize(stride, height);
+                    uint8_t* pixels = (stride > 0 && totalSize > 0) ? ctx.allocator(totalSize) : nullptr;
                     if (!pixels) {
                         avifRGBImageFreePixels(&rgb);
                         avifDecoderDestroy(decoder);
@@ -5459,10 +5460,10 @@ namespace QuickView {
                                 if (thumb->bits == 8 && thumb->colors == 3) {
                                     int w = thumb->width;
                                     int h = thumb->height;
-                                    int stride = CalculateSIMDAlignedStride(w, 4); 
-                                    size_t totalSize = (size_t)stride * h;
+                                    int stride = SafeCalculateStride(w, 4);
+                                    size_t totalSize = SafeCalculateBufferSize(stride, h);
                                     
-                                    uint8_t* pixels = ctx.allocator(totalSize);
+                                    uint8_t* pixels = (stride > 0 && totalSize > 0) ? ctx.allocator(totalSize) : nullptr;
                                     if (pixels) {
                                         uint8_t* src = (uint8_t*)thumb->data;
                                         uint8_t* dst = pixels;
@@ -5533,10 +5534,10 @@ namespace QuickView {
                 if (image->type == LIBRAW_IMAGE_BITMAP && image->bits == 8 && image->colors == 3) {
                      int w = image->width;
                      int h = image->height;
-                     int stride = CalculateSIMDAlignedStride(w, 4);
-                     size_t totalSize = (size_t)stride * h;
+                     int stride = SafeCalculateStride(w, 4);
+                     size_t totalSize = SafeCalculateBufferSize(stride, h);
                      
-                     uint8_t* pixels = ctx.allocator(totalSize);
+                     uint8_t* pixels = (stride > 0 && totalSize > 0) ? ctx.allocator(totalSize) : nullptr;
                      if (!pixels) {
                          RawProcessor.dcraw_clear_mem(image);
                          return E_OUTOFMEMORY;
@@ -5609,9 +5610,9 @@ namespace QuickView {
                 }
 
                 const int bytesPerPixel = 16;
-                int stride = CalculateSIMDAlignedStride(outW, bytesPerPixel);
-                size_t totalSize = (size_t)stride * outH;
-                uint8_t* pixels = ctx.allocator(totalSize);
+                int stride = SafeCalculateStride(outW, bytesPerPixel);
+                size_t totalSize = SafeCalculateBufferSize(stride, outH);
+                uint8_t* pixels = (stride > 0 && totalSize > 0) ? ctx.allocator(totalSize) : nullptr;
                 if (!pixels) return E_OUTOFMEMORY;
 
                 std::vector<int> srcXForOut(outW);
@@ -5850,11 +5851,9 @@ namespace QuickView {
                     }
                 }
 
-                const int stride = CalculateSIMDAlignedStride(static_cast<int>(outW), 4);
-                if (stride <= 0) return E_FAIL;
-
-                const size_t totalSize = static_cast<size_t>(stride) * static_cast<size_t>(outH);
-                uint8_t* pixels = ctx.allocator(totalSize);
+                const int stride = SafeCalculateStride(static_cast<int>(outW), 4);
+                const size_t totalSize = SafeCalculateBufferSize(stride, static_cast<int>(outH));
+                uint8_t* pixels = (stride > 0 && totalSize > 0) ? ctx.allocator(totalSize) : nullptr;
                 if (!pixels) return E_OUTOFMEMORY;
 
                 std::memset(pixels, 0, totalSize);
@@ -5973,9 +5972,9 @@ namespace QuickView {
                      // It says "LoadImage" - usually wrapping stbi_load_from_memory forcing 4 components?
                      // Assuming RGBA output from StbLoader wrapper.
                      
-                     int stride = CalculateSIMDAlignedStride(w, 4);
-                     size_t totalSize = (size_t)stride * h;
-                     uint8_t* pixels = ctx.allocator(totalSize);
+                     int stride = SafeCalculateStride(w, 4);
+                     size_t totalSize = SafeCalculateBufferSize(stride, h);
+                     uint8_t* pixels = (stride > 0 && totalSize > 0) ? ctx.allocator(totalSize) : nullptr;
                      if (!pixels) return E_OUTOFMEMORY;
                      
                      // [v9.9] Copy and Convert RGBA to BGRA with OpenMP parallelization
@@ -6020,9 +6019,9 @@ namespace QuickView {
                 }
 
                 const int bytesPerPixel = 16;
-                const int stride = CalculateSIMDAlignedStride(w, bytesPerPixel);
-                const size_t totalSize = static_cast<size_t>(stride) * h;
-                uint8_t* pixels = ctx.allocator(totalSize);
+                const int stride = SafeCalculateStride(w, bytesPerPixel);
+                const size_t totalSize = SafeCalculateBufferSize(stride, h);
+                uint8_t* pixels = (stride > 0 && totalSize > 0) ? ctx.allocator(totalSize) : nullptr;
                 if (!pixels) return E_OUTOFMEMORY;
 
                 for (int y = 0; y < h; ++y) {
@@ -10341,9 +10340,9 @@ HRESULT CImageLoader::LoadToFrame(LPCWSTR filePath, QuickView::RawImageFrame* ou
     }
 
     // Allocate output buffer with aligned stride
-    int outStride = CalculateSIMDAlignedStride(finalW, 4);
-    size_t outSize = static_cast<size_t>(outStride) * finalH;
-    uint8_t* pixels = AllocateBuffer(outSize);
+    int outStride = SafeCalculateStride(finalW, 4);
+    size_t outSize = SafeCalculateBufferSize(outStride, finalH);
+    uint8_t* pixels = (outStride > 0 && outSize > 0) ? AllocateBuffer(outSize) : nullptr;
     if (!pixels) return E_OUTOFMEMORY;
     
     if (needWicResize) {
@@ -10630,8 +10629,9 @@ static bool TryDecodeAvifGainMappedLinearRGBA(
 
     const int width = static_cast<int>(toneMappedRgb.width);
     const int height = static_cast<int>(toneMappedRgb.height);
-    const int stride = CalculateSIMDAlignedStride(width, 16);
-    uint8_t* pixels = ctx.allocator(static_cast<size_t>(stride) * height);
+    const int stride = SafeCalculateStride(width, 16);
+    const size_t totalSize = SafeCalculateBufferSize(stride, height);
+    uint8_t* pixels = (stride > 0 && totalSize > 0) ? ctx.allocator(totalSize) : nullptr;
     if (!pixels) {
         avifRGBImageFreePixels(&toneMappedRgb);
         return false;

--- a/QuickView/ImageTypes.h
+++ b/QuickView/ImageTypes.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <limits>
 #include "DisplayColorInfo.h"
 
 namespace QuickView {
@@ -264,6 +265,49 @@ private:
 /// Calculate 64-byte (cache line) aligned stride for SIMD operations
 [[nodiscard]] inline int CalculateSIMDAlignedStride(int width, int bytesPerPixel) noexcept {
     return CalculateAlignedStride(width, bytesPerPixel, 64);
+}
+
+// ============================================================================
+// [Security Fix] Safe Buffer Calculation Helpers
+// ============================================================================
+
+/// Calculate aligned stride with overflow protection.
+/// Returns 0 on overflow or invalid input.
+[[nodiscard]] inline int SafeCalculateStride(int width, int bytesPerPixel, int alignment = 64) noexcept {
+    if (width <= 0 || bytesPerPixel <= 0 || alignment <= 0) return 0;
+
+    const uint64_t w = static_cast<uint64_t>(width);
+    const uint64_t bpp = static_cast<uint64_t>(bytesPerPixel);
+    const uint64_t align = static_cast<uint64_t>(alignment);
+
+    // Check width * bytesPerPixel overflow
+    if (w > 0 && bpp > std::numeric_limits<uint64_t>::max() / w) return 0;
+    const uint64_t rawStride = w * bpp;
+
+    // Check alignment addition overflow: (rawStride + align - 1)
+    if (rawStride > std::numeric_limits<uint64_t>::max() - (align - 1)) return 0;
+    const uint64_t alignedStride = (rawStride + align - 1) & ~(align - 1);
+
+    // Final check for int cast
+    if (alignedStride > static_cast<uint64_t>(std::numeric_limits<int>::max())) return 0;
+
+    return static_cast<int>(alignedStride);
+}
+
+/// Calculate total buffer size with overflow protection.
+/// Returns 0 on overflow or invalid input.
+[[nodiscard]] inline size_t SafeCalculateBufferSize(int stride, int height) noexcept {
+    if (stride <= 0 || height <= 0) return 0;
+
+    const uint64_t s = static_cast<uint64_t>(stride);
+    const uint64_t h = static_cast<uint64_t>(height);
+
+    if (s > 0 && h > std::numeric_limits<uint64_t>::max() / s) return 0;
+    const uint64_t totalSize = s * h;
+
+    if (totalSize > std::numeric_limits<size_t>::max()) return 0;
+
+    return static_cast<size_t>(totalSize);
 }
 
 } // namespace QuickView

--- a/QuickView/StbLoader.cpp
+++ b/QuickView/StbLoader.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "StbLoader.h"
+#include "ImageTypes.h"
 
 // Define implementation for stb_image
 #define STB_IMAGE_IMPLEMENTATION
@@ -69,7 +70,12 @@ namespace StbLoader {
         *channels = 4;
 
         size_t pixelSize = useFloat ? sizeof(float) : sizeof(uint8_t);
-        size_t totalSize = w * h * 4 * pixelSize;
+        size_t totalSize = QuickView::SafeCalculateBufferSize(w * 4, h);
+        if (totalSize == 0) {
+            stbi_image_free(data);
+            return false;
+        }
+        totalSize *= pixelSize;
 
         outData.resize(totalSize);
         memcpy(outData.data(), data, totalSize);
@@ -98,7 +104,12 @@ namespace StbLoader {
         *channels = 4;
 
         size_t pixelSize = useFloat ? sizeof(float) : sizeof(uint8_t);
-        size_t totalSize = w * h * 4 * pixelSize;
+        size_t totalSize = QuickView::SafeCalculateBufferSize(w * 4, h);
+        if (totalSize == 0) {
+            stbi_image_free(data);
+            return false;
+        }
+        totalSize *= pixelSize;
 
         outData.resize(totalSize);
         memcpy(outData.data(), data, totalSize);


### PR DESCRIPTION
The vulnerability involved unvalidated integer multiplication when calculating the total buffer size for RGB bitmaps (`totalSize = (size_t)stride * h`). If `stride * h` overflowed, it could lead to an undersized memory allocation, which would then be overwritten during image data copying, causing a heap buffer overflow.

I addressed this by:
1.  **Creating Safe Helpers:** Introduced `SafeCalculateStride` and `SafeCalculateBufferSize` in `QuickView/ImageTypes.h`. These functions use `uint64_t` for intermediate calculations and perform explicit checks against `std::numeric_limits` for both multiplication and alignment addition.
2.  **Updating Call Sites:** Replaced all manual calculations in `QuickView/ImageLoader.cpp` (11 locations) and `QuickView/StbLoader.cpp` (2 locations) with these safe helpers.
3.  **Enhancing Error Handling:** Added checks to ensure that if a calculation fails (returns 0), the application correctly identifies it as a memory error and performs necessary cleanup (like freeing decoder objects or returning `E_OUTOFMEMORY`).

I verified the fix using a standalone test harness that simulated various overflow scenarios, ensuring the logic is robust and correct.

---
*PR created automatically by Jules for task [5626045199991967741](https://jules.google.com/task/5626045199991967741) started by @justnullname*