### PR TITLE
⚡ [performance improvement] Cache m_infoGrid size in loops

### DIFF
--- a/QuickView/UIRenderer.cpp
+++ b/QuickView/UIRenderer.cpp
@@ -148,7 +148,8 @@ HitTestResult UIRenderer::HitTest(float x, float y) {
         float rowH = GRID_ROW_HEIGHT * s;
         
         float rowY = startY;
-        for (size_t i = 0; i < m_infoGrid.size(); i++) {
+        const size_t gridSize = m_infoGrid.size();
+        for (size_t i = 0; i < gridSize; i++) {
             D2D1_RECT_F rowRect = D2D1::RectF(startX, rowY, startX + width, rowY + rowH);
             
             if (x >= rowRect.left && x <= rowRect.right &&
@@ -1412,7 +1413,8 @@ void UIRenderer::DrawInfoGrid(ID2D1DeviceContext* dc, float startX, float startY
     float valueColWidth = width - iconW - labelW - gridPad;
     float y = startY;
     
-    for (size_t i = 0; i < m_infoGrid.size(); i++) {
+    const size_t gridSize = m_infoGrid.size();
+    for (size_t i = 0; i < gridSize; i++) {
         auto& row = m_infoGrid[i];
         
         // Calculate hit rect


### PR DESCRIPTION
💡 **What:** Cached `m_infoGrid.size()` in loops within `HitTest` and `DrawInfoGrid`.

🎯 **Why:** Prevents repeated calls to `.size()` in the loop condition. While `std::vector::size()` is O(1) in C++, caching it avoids redundant pointer subtraction in hot rendering and hit-testing paths, which is a standard micro-optimization for high-performance UI code.

📊 **Measured Improvement:** Benchmarking Windows-specific UI code in a Linux sandbox is impractical. However, this is a well-established performance best practice in modern C++ for code paths executed frequently during frame rendering and input handling.

---
*PR created automatically by Jules for task [8809102899333472946](https://jules.google.com/task/8809102899333472946) started by @justnullname*