### PR TITLE
feat: Upgrade Advanced Color to three-state with Auto mode

### DIFF
--- a/QuickView/AppStrings.cpp
+++ b/QuickView/AppStrings.cpp
@@ -285,6 +285,7 @@ const wchar_t *Settings_Option_White = nullptr;
 const wchar_t *Settings_Option_Grid = nullptr;
 const wchar_t *Settings_Option_Custom = nullptr;
 const wchar_t *Settings_Option_Off = nullptr;
+const wchar_t *Settings_Option_On = nullptr;
 const wchar_t *Settings_Option_Lite = nullptr;
 const wchar_t *Settings_Option_Full = nullptr;
 const wchar_t *Settings_Option_LargeOnly = nullptr;
@@ -709,6 +710,7 @@ struct EN {
   static constexpr const wchar_t *Settings_Option_Grid = L"Grid";
   static constexpr const wchar_t *Settings_Option_Custom = L"Custom";
   static constexpr const wchar_t *Settings_Option_Off = L"Off";
+  static constexpr const wchar_t *Settings_Option_On = L"On";
   static constexpr const wchar_t *Settings_Option_Lite = L"Lite";
   static constexpr const wchar_t *Settings_Option_Full = L"Full";
   static constexpr const wchar_t *Settings_Option_LargeOnly = L"Large Only";
@@ -1008,6 +1010,7 @@ struct CN {
   static constexpr const wchar_t *Settings_Option_Grid = L"网格";
   static constexpr const wchar_t *Settings_Option_Custom = L"自定义";
   static constexpr const wchar_t *Settings_Option_Off = L"关闭";
+  static constexpr const wchar_t *Settings_Option_On = L"开启";
   static constexpr const wchar_t *Settings_Option_Lite = L"简略";
   static constexpr const wchar_t *Settings_Option_Full = L"详细";
   static constexpr const wchar_t *Settings_Option_LargeOnly = L"仅大图";
@@ -1556,6 +1559,7 @@ struct TW {
   static constexpr const wchar_t *Settings_Option_Grid = L"網格";
   static constexpr const wchar_t *Settings_Option_Custom = L"自訂";
   static constexpr const wchar_t *Settings_Option_Off = L"關閉";
+  static constexpr const wchar_t *Settings_Option_On = L"開啟";
   static constexpr const wchar_t *Settings_Option_Lite = L"簡略";
   static constexpr const wchar_t *Settings_Option_Full = L"詳細";
   static constexpr const wchar_t *Settings_Option_LargeOnly = L"僅大圖";
@@ -1989,6 +1993,7 @@ struct JA {
   static constexpr const wchar_t *Settings_Option_Grid = L"グリッド";
   static constexpr const wchar_t *Settings_Option_Custom = L"カスタム";
   static constexpr const wchar_t *Settings_Option_Off = L"オフ";
+  static constexpr const wchar_t *Settings_Option_On = L"オン";
   static constexpr const wchar_t *Settings_Option_Lite = L"簡易";
   static constexpr const wchar_t *Settings_Option_Full = L"詳細";
   static constexpr const wchar_t *Settings_Option_LargeOnly = L"大きい画像のみ";
@@ -2482,6 +2487,7 @@ struct RU {
   static constexpr const wchar_t *Settings_Option_Grid = L"Сетка";
   static constexpr const wchar_t *Settings_Option_Custom = L"Свой";
   static constexpr const wchar_t *Settings_Option_Off = L"Выкл";
+  static constexpr const wchar_t *Settings_Option_On = L"Вкл";
   static constexpr const wchar_t *Settings_Option_Lite = L"Кратко";
   static constexpr const wchar_t *Settings_Option_Full = L"Полностью";
   static constexpr const wchar_t *Settings_Option_LargeOnly = L"Только большие";
@@ -2936,6 +2942,7 @@ struct DE {
   static constexpr const wchar_t *Settings_Option_Grid = L"Raster";
   static constexpr const wchar_t *Settings_Option_Custom = L"Benutzerdefiniert";
   static constexpr const wchar_t *Settings_Option_Off = L"Aus";
+  static constexpr const wchar_t *Settings_Option_On = L"Ein";
   static constexpr const wchar_t *Settings_Option_Lite = L"Kompakt";
   static constexpr const wchar_t *Settings_Option_Full = L"Vollständig";
   static constexpr const wchar_t *Settings_Option_LargeOnly = L"Nur Große";
@@ -3416,6 +3423,7 @@ struct ES {
   static constexpr const wchar_t *Settings_Option_Grid = L"Cuadrícula";
   static constexpr const wchar_t *Settings_Option_Custom = L"Personalizado";
   static constexpr const wchar_t *Settings_Option_Off = L"Desactivado";
+  static constexpr const wchar_t *Settings_Option_On = L"Activado";
   static constexpr const wchar_t *Settings_Option_Lite = L"Compacto";
   static constexpr const wchar_t *Settings_Option_Full = L"Completo";
   static constexpr const wchar_t *Settings_Option_LargeOnly = L"Solo grandes";
@@ -3802,6 +3810,7 @@ template <typename T> void ApplyT() {
   Settings_Option_Grid = T::Settings_Option_Grid;
   Settings_Option_Custom = T::Settings_Option_Custom;
   Settings_Option_Off = T::Settings_Option_Off;
+  Settings_Option_On = T::Settings_Option_On;
   Settings_Option_Lite = T::Settings_Option_Lite;
   Settings_Option_Full = T::Settings_Option_Full;
   Settings_Option_LargeOnly = T::Settings_Option_LargeOnly;

--- a/QuickView/AppStrings.h
+++ b/QuickView/AppStrings.h
@@ -234,6 +234,7 @@ namespace AppStrings {
     extern const wchar_t* Settings_Option_Custom;
     extern const wchar_t* Settings_Option_ZoomAuto;
     extern const wchar_t* Settings_Option_Off;
+    extern const wchar_t* Settings_Option_On;
     extern const wchar_t* Settings_Option_Lite;
     extern const wchar_t* Settings_Option_Full;
     extern const wchar_t* Settings_Option_LargeOnly;

--- a/QuickView/EditState.h
+++ b/QuickView/EditState.h
@@ -145,7 +145,7 @@ struct AppConfig {
     bool ColorManagement = true;         // Master toggle for Color Management System
     int CmsRenderingIntent = 1;          // 0=Perceptual, 1=Relative Colorimetric
     int HdrToneMappingMode = 0;          // 0=Perceptual, 1=Colorimetric
-    bool EnableAdvancedColor = false;    // HDR / FP16 scRGB pipeline toggle
+    int AdvancedColorMode = 2;           // 0=Off, 1=On, 2=Auto (HDR / FP16 scRGB pipeline)
     int CmsDefaultFallback = 0;          // Fallback for untagged images: 0=sRGB, 1=P3, 2=AdobeRGB, 3=ProPhoto
     std::wstring CustomSoftProofProfile; // Path to user-selected ICC file for soft proofing
     std::wstring CustomEditorPath;       // Path to user-selected custom image editor executable
@@ -170,6 +170,11 @@ struct AppConfig {
     bool ForceRawDecode = false;         
     bool RenderRAW = false;
     
+    /// <summary>
+    bool IsAdvancedColorEnabled(bool systemSupportsHdr) const {
+        return AdvancedColorMode == 1 || (AdvancedColorMode == 2 && systemSupportsHdr);
+    }
+
     /// <summary>
     /// Should auto-save for given quality?
     /// </summary>

--- a/QuickView/RenderEngine.cpp
+++ b/QuickView/RenderEngine.cpp
@@ -493,7 +493,7 @@ HRESULT CRenderEngine::ResolveDestinationColorContext(
     return E_INVALIDARG;
   *outContext = nullptr;
 
-  if (m_isAdvancedColor && g_config.EnableAdvancedColor) {
+  if (m_isAdvancedColor && g_config.IsAdvancedColorEnabled(m_displayColorState.advancedColorSupported)) {
     return m_d2dContext->CreateColorContext(D2D1_COLOR_SPACE_SCRGB, nullptr, 0,
                                             outContext);
   }
@@ -624,7 +624,7 @@ CRenderEngine::UploadRawFrameToGPU(const QuickView::RawImageFrame &frame,
       case QuickView::GpuBlendOp::UltraHdrGainMap: {
           // Fill target headroom from current display state
           QuickView::GpuShaderPayload payload = frame.shaderPayload;
-          if (m_isAdvancedColor && g_config.EnableAdvancedColor) {
+          if (m_isAdvancedColor && g_config.IsAdvancedColorEnabled(m_displayColorState.advancedColorSupported)) {
               payload.targetHeadroom = m_displayColorState.GetHdrHeadroomStops();
           } else {
               payload.targetHeadroom = 0.0f; // SDR: no gain applied
@@ -719,7 +719,7 @@ CRenderEngine::UploadRawFrameToGPU(const QuickView::RawImageFrame &frame,
       ComPtr<ID2D1ColorContext> scRgbContext;
       CreateScRgbColorContext(m_d2dContext.Get(), &scRgbContext);
 
-      if (m_isAdvancedColor && g_config.EnableAdvancedColor) {
+      if (m_isAdvancedColor && g_config.IsAdvancedColorEnabled(m_displayColorState.advancedColorSupported)) {
           // Pure HDR Environment (Roll-off)
           const QuickView::ToneMapSettings toneMapSettings = BuildToneMapSettings(frame, m_displayColorState);
           if (m_computeEngine && m_computeEngine->IsAvailable() && toneMapSettings.contentPeakScRgb > (toneMapSettings.displayPeakScRgb > 1.0f ? toneMapSettings.displayPeakScRgb : 1.0f)) {

--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -1205,7 +1205,7 @@ void SettingsOverlay::BuildMenu() {
     };
     tabImage.items.push_back(itemCmsIntent);
 
-    SettingsItem itemAdvColor = { AppStrings::Settings_Label_AdvancedColor, OptionType::Toggle, &g_config.EnableAdvancedColor };
+    SettingsItem itemAdvColor = { AppStrings::Settings_Label_AdvancedColor, OptionType::Segment, nullptr, nullptr, &g_config.AdvancedColorMode, nullptr, 0, 0, {AppStrings::Settings_Option_Off, AppStrings::Settings_Option_On, AppStrings::Settings_Option_Auto} };
     itemAdvColor.tooltipText = AppStrings::Settings_Tooltip_AdvancedColor;
     itemAdvColor.onChange = []() {
         SaveConfig();

--- a/QuickView/UIRenderer.cpp
+++ b/QuickView/UIRenderer.cpp
@@ -1961,7 +1961,7 @@ namespace {
                                              const QuickView::DisplayColorState& displayState) {
         const bool hdrContent = IsHdrLikeContent(metadata);
         if (hdrContent) {
-            if (displayState.advancedColorActive && g_config.EnableAdvancedColor) {
+            if (displayState.advancedColorActive && g_config.IsAdvancedColorEnabled(displayState.advancedColorSupported)) {
                 return L"[HDR Direct] DirectComposition scRGB (FP16)";
             }
             return L"[SDR Fallback] GPU Tone Mapped to SDR";

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -2515,8 +2515,8 @@ void RequestRepaint(PaintLayer layer) {
 static void RefreshDisplayColorPipeline(HWND hwnd, bool requestFullRepaint) {
     if (!g_compEngine) return;
 
-    g_compEngine->SetAdvancedColorEnabled(g_config.EnableAdvancedColor);
     const bool changed = g_compEngine->RefreshDisplayColorState(g_runtime.ForceHdrSimulation);
+    g_compEngine->SetAdvancedColorEnabled(g_config.IsAdvancedColorEnabled(g_compEngine->GetDisplayColorState().advancedColorSupported));
     const float displayHdrHeadroomStops = GetCurrentDisplayHdrHeadroomStops();
     if (g_renderEngine) {
         g_renderEngine->SetAdvancedColorMode(g_compEngine->IsAdvancedColor());
@@ -4248,7 +4248,7 @@ void SaveConfig() {
     // Image
     WritePrivateProfileStringW(L"Image", L"AutoRotate", std::to_wstring(g_config.AutoRotate).c_str(), iniPath.c_str());
     WritePrivateProfileStringW(L"Image", L"ColorManagement", g_config.ColorManagement ? L"1" : L"0", iniPath.c_str());
-    WritePrivateProfileStringW(L"Image", L"EnableAdvancedColor", g_config.EnableAdvancedColor ? L"1" : L"0", iniPath.c_str());
+    WritePrivateProfileStringW(L"Image", L"AdvancedColorMode", std::to_wstring(g_config.AdvancedColorMode).c_str(), iniPath.c_str());
     WritePrivateProfileStringW(L"Image", L"CmsDefaultFallback", std::to_wstring(g_config.CmsDefaultFallback).c_str(), iniPath.c_str());
     WritePrivateProfileStringW(L"Image", L"CmsRenderingIntent", std::to_wstring(g_config.CmsRenderingIntent).c_str(), iniPath.c_str());
     WritePrivateProfileStringW(L"Image", L"HdrToneMappingMode", std::to_wstring(g_config.HdrToneMappingMode).c_str(), iniPath.c_str());
@@ -4380,7 +4380,7 @@ void LoadConfig() {
     // Image
     g_config.AutoRotate = GetPrivateProfileIntW(L"Image", L"AutoRotate", 1, iniPath.c_str()) != 0;
     g_config.ColorManagement = GetPrivateProfileIntW(L"Image", L"ColorManagement", 1, iniPath.c_str()) != 0;
-    g_config.EnableAdvancedColor = GetPrivateProfileIntW(L"Image", L"EnableAdvancedColor", 0, iniPath.c_str()) != 0;
+    g_config.AdvancedColorMode = GetPrivateProfileIntW(L"Image", L"AdvancedColorMode", 2, iniPath.c_str());
     g_config.CmsDefaultFallback = GetPrivateProfileIntW(L"Image", L"CmsDefaultFallback", 0, iniPath.c_str());
     g_config.CmsRenderingIntent = GetPrivateProfileIntW(L"Image", L"CmsRenderingIntent", 1, iniPath.c_str());
     g_config.HdrToneMappingMode = GetPrivateProfileIntW(L"Image", L"HdrToneMappingMode", 0, iniPath.c_str());
@@ -5775,8 +5775,9 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int nCmdSh
     // Initialize DirectComposition (Visual Ping-Pong Architecture)
     // g_compEngine = std::make_unique<CompositionEngine>();
     g_compEngine = new CompositionEngine();
-    g_compEngine->SetAdvancedColorEnabled(g_config.EnableAdvancedColor);
     if (SUCCEEDED(g_compEngine->Initialize(hwnd, g_renderEngine->GetD3DDevice(), g_renderEngine->GetD2DDevice()))) {
+        g_compEngine->RefreshDisplayColorState(g_runtime.ForceHdrSimulation);
+        g_compEngine->SetAdvancedColorEnabled(g_config.IsAdvancedColorEnabled(g_compEngine->GetDisplayColorState().advancedColorSupported));
         g_renderEngine->SetAdvancedColorMode(g_compEngine->IsAdvancedColor());
         g_renderEngine->SetDisplayColorState(g_compEngine->GetDisplayColorState());
         // Pure DComp architecture: Surfaces are managed by CompositionEngine
@@ -9605,7 +9606,7 @@ void ProcessEngineEvents(HWND hwnd) {
 
     case EventType::AuxLayerReady:
         if (evt.imageId == g_currentImageId.load() && evt.auxLayer) {
-            if (g_config.EnableAdvancedColor) {
+            if (g_compEngine && g_config.IsAdvancedColorEnabled(g_compEngine->GetDisplayColorState().advancedColorSupported)) {
                 // Update active resource with the gain map
                 g_imageResource.blendOp = evt.blendOp;
                 g_imageResource.shaderPayload = evt.shaderPayload;


### PR DESCRIPTION
Resolves user request to upgrade the Advanced Color setting from a simple Toggle to a three-state option (Auto, Off, On), where Auto dynamically reflects the OS hardware capabilities.

---
*PR created automatically by Jules for task [16434532853780799539](https://jules.google.com/task/16434532853780799539) started by @justnullname*