### PR TITLE
Fix AVIF HDR gain map decoding crash

### DIFF
--- a/QuickView/ImageLoader.cpp
+++ b/QuickView/ImageLoader.cpp
@@ -5922,6 +5922,8 @@ namespace QuickView {
                 avifDecoder* decoder = avifDecoderCreate();
                 if (!decoder) return E_OUTOFMEMORY;
 
+                decoder->imageContentToDecode |= AVIF_IMAGE_CONTENT_GAIN_MAP;
+
                 decoder->strictFlags = AVIF_STRICT_DISABLED;
                 const unsigned int threads = std::thread::hardware_concurrency();
                 decoder->maxThreads = threads > 0 ? threads : 4;


### PR DESCRIPTION
Fixes an access violation (0xC0000005) when opening some AVIF HDR files. `libavif` version 1.4.0 (used in this repository) deprecated `enableDecodingGainMap` and introduced `imageContentToDecode`. This patch ensures the gain map is properly requested from the decoder so that tone mapping succeeds without crashing.

---
*PR created automatically by Jules for task [18097903921322488281](https://jules.google.com/task/18097903921322488281) started by @justnullname*