### PR TITLE
Fix bottom edge indicator not displaying when toolbar is pinned

### DIFF
--- a/QuickView/UIRenderer.cpp
+++ b/QuickView/UIRenderer.cpp
@@ -1449,14 +1449,8 @@ void UIRenderer::DrawBorderIndicators(ID2D1DeviceContext* dc) {
         dc->FillRectangle(rect, borderBrush.Get());
     }
     if (drawBottom) {
-        // Exclude bottom edge if toolbar is pinned or hovered to avoid overlap issues
-        bool showBottom = true;
-        if (g_toolbar.IsVisible() || g_config.LockBottomToolbar) showBottom = false;
-
-        if (showBottom) {
-            D2D1_RECT_F rect = D2D1::RectF(0.0f, winH - thickness, winW, winH);
-            dc->FillRectangle(rect, borderBrush.Get());
-        }
+        D2D1_RECT_F rect = D2D1::RectF(0.0f, winH - thickness, winW, winH);
+        dc->FillRectangle(rect, borderBrush.Get());
     }
 }
 


### PR DESCRIPTION
The bottom edge indicator was previously hidden when the toolbar was visible or pinned to allegedly avoid overlap issues. However, the toolbar has a 24px bottom margin and the indicator is only 4px thick at the very bottom edge, so they do not overlap. The logic hiding the indicator has been removed, ensuring the blue line properly appears when the image exceeds the bottom window boundary.

---
*PR created automatically by Jules for task [16370339799946136550](https://jules.google.com/task/16370339799946136550) started by @justnullname*