### PR TITLE
Fix Advanced Color HDR mode handling

### DIFF
--- a/QuickView/ImageLoader.cpp
+++ b/QuickView/ImageLoader.cpp
@@ -5841,7 +5841,7 @@ namespace QuickView {
                              transfer = MapJxlTransferFunction(encodedColor.transfer_function);
                              primaries = MapJxlPrimaries(encodedColor.primaries);
                             useFloatOutput =
-                                !ctx.forcePreview &&
+                                !ctx.forcePreview && !PrefersSdrTarget(ctx) &&
                                 (transfer == QuickView::TransferFunction::Linear ||
                                  transfer == QuickView::TransferFunction::PQ ||
                                  transfer == QuickView::TransferFunction::HLG ||
@@ -6175,7 +6175,7 @@ namespace QuickView {
         const QuickView::TransferFunction transfer = MapAvifTransferFunction(decoder->image->transferCharacteristics);
         const QuickView::ColorPrimaries primaries = MapAvifPrimaries(decoder->image->colorPrimaries);
         const bool preferSdrTarget = PrefersSdrTarget(ctx);
-        const bool useFloatOutput =
+        const bool useFloatOutput = !preferSdrTarget &&
                     (decoder->image->gainMap != nullptr ||
                      transfer == QuickView::TransferFunction::Linear ||
                      transfer == QuickView::TransferFunction::PQ ||
@@ -7129,7 +7129,7 @@ namespace QuickView {
 
                 UINT w, h;
                 frame->GetSize(&w, &h);
-                int bpp = isHighBitDepth ? 16 : 4;
+                int bpp = (isHighBitDepth && !PrefersSdrTarget(ctx)) ? 16 : 4;
                 int stride = CalculateSIMDAlignedStride(w, bpp);
                 size_t bufSize = (size_t)stride * h;
                 uint8_t* pixels = ctx.allocator(bufSize);

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -2582,8 +2582,8 @@ static void RefreshDisplayColorPipeline(HWND hwnd, bool requestFullRepaint) {
     const bool changed = g_compEngine->RefreshDisplayColorState(g_runtime.ForceHdrSimulation);
     g_compEngine->SetAdvancedColorEnabled(g_config.IsAdvancedColorEnabled(g_compEngine->GetDisplayColorState().advancedColorSupported));
     const float rawHeadroom = GetCurrentDisplayHdrHeadroomStops();
-    const float displayHdrHeadroomStops = g_compEngine->IsAdvancedColor() ? 
-        (rawHeadroom < 0.1f ? -1.0f : rawHeadroom) : 0.0f;
+    const float displayHdrHeadroomStops = (g_config.AdvancedColorMode != 0) ?
+        (g_compEngine->IsAdvancedColor() ? (rawHeadroom < 0.1f ? -1.0f : rawHeadroom) : -1.0f) : 0.0f;
     if (g_renderEngine) {
         g_renderEngine->SetAdvancedColorMode(g_compEngine->IsAdvancedColor());
         g_renderEngine->SetDisplayColorState(g_compEngine->GetDisplayColorState());
@@ -2626,6 +2626,9 @@ static float GetCurrentDisplayHdrHeadroomStops() {
 }
 
 static float GetDisplayHdrHeadroomStopsForPane(HWND hwnd, ComparePane pane) {
+    if (g_config.AdvancedColorMode == 0) return 0.0f;
+    if (g_compEngine && !g_compEngine->IsAdvancedColor()) return -1.0f;
+
     QuickView::DisplayColorState paneState = {};
     if (GetDisplayColorStateForPane(hwnd, pane, &paneState)) {
         return paneState.GetHdrHeadroomStops();


### PR DESCRIPTION
This commit fixes the issue where the "Advanced Color & HDR" setting did not correctly force 8-bit output when turned off or HDR output when set to Auto/On regardless of monitor capability.

Changes made:
- Updated `RefreshDisplayColorPipeline` to evaluate `g_config.AdvancedColorMode` rather than strictly relying on `IsAdvancedColor()` when computing `displayHdrHeadroomStops`. When the setting is off, it outputs 0.0f (SDR). When on/auto, it outputs -1.0f or the HDR headroom if advanced color is enabled, forcing the decoder to output HDR.
- Updated `GetDisplayHdrHeadroomStopsForPane` similarly.
- Updated `useFloatOutput` in `QuickView/ImageLoader.cpp` to explicitly depend on `!preferSdrTarget`, enforcing the float output decision based on the `targetHdrHeadroomStops`.
- Corrected the `bpp` bit depth calculation in `LoadImageUnified` when setting up `WICBitmapDitherTypeNone` conversion to depend on `!PrefersSdrTarget(ctx)`.

---
*PR created automatically by Jules for task [15989960553768700680](https://jules.google.com/task/15989960553768700680) started by @justnullname*