### PR TITLE
Add Ctrl+Wheel zoom lock and Alt+Wheel zoom speed adjustment

### DIFF
--- a/QuickView/AppStrings.cpp
+++ b/QuickView/AppStrings.cpp
@@ -228,6 +228,11 @@ const wchar_t *Settings_Label_InvertWheel = nullptr;
 const wchar_t *Settings_Label_ZoomSnapDamping = nullptr; // New
 const wchar_t *Settings_Label_MouseAnchorZoom = nullptr;
 const wchar_t *Settings_Label_RightButtonDragZoom = nullptr;
+const wchar_t *Settings_Label_WheelZoomSpeed = nullptr;
+const wchar_t *Settings_Label_RightDragZoomSpeed = nullptr;
+const wchar_t *OSD_WheelZoomSpeed = nullptr;
+const wchar_t *Help_Action_AdjustZoomSpeed = nullptr;
+const wchar_t *Help_Action_LockWindowZoom = nullptr;
 const wchar_t *Settings_Label_InvertButtons = nullptr;
 const wchar_t *Settings_Label_ZoomModeIn = nullptr;
 const wchar_t *Settings_Label_ZoomModeOut = nullptr;
@@ -791,6 +796,11 @@ struct EN {
       L"Mouse-Anchored Window Zoom";
   static constexpr const wchar_t *Settings_Label_RightButtonDragZoom =
       L"Right Button Drag Zoom";
+  static constexpr const wchar_t *Settings_Label_WheelZoomSpeed = L"Wheel Zoom Speed";
+  static constexpr const wchar_t *Settings_Label_RightDragZoomSpeed = L"Right Drag Zoom Speed";
+  static constexpr const wchar_t *OSD_WheelZoomSpeed = L"Zoom Speed: ";
+  static constexpr const wchar_t *Help_Action_AdjustZoomSpeed = L"Adjust Zoom Speed";
+  static constexpr const wchar_t *Help_Action_LockWindowZoom = L"Temporarily Lock Window Zoom";
   static constexpr const wchar_t *Settings_Label_InvertButtons =
       L"Invert Side Buttons";
   static constexpr const wchar_t *Settings_Label_ZoomModeIn = L"Zoom Mode (In)";
@@ -1182,6 +1192,11 @@ struct CN {
       L"窗口缩放以鼠标为中线";
   static constexpr const wchar_t *Settings_Label_RightButtonDragZoom =
       L"右键拖动缩放";
+  static constexpr const wchar_t *Settings_Label_WheelZoomSpeed = L"滚轮缩放速度";
+  static constexpr const wchar_t *Settings_Label_RightDragZoomSpeed = L"右键拖拽缩放速度";
+  static constexpr const wchar_t *OSD_WheelZoomSpeed = L"缩放速度: ";
+  static constexpr const wchar_t *Help_Action_AdjustZoomSpeed = L"调节缩放速度";
+  static constexpr const wchar_t *Help_Action_LockWindowZoom = L"临时锁定窗口缩放";
   static constexpr const wchar_t *Settings_Label_InvertButtons = L"反转侧键";
   static constexpr const wchar_t *Settings_Label_ZoomModeIn = L"放大插值算法";
   static constexpr const wchar_t *Settings_Label_ZoomModeOut = L"缩小插值算法";
@@ -1772,6 +1787,11 @@ struct TW {
       L"視窗縮放以滑鼠為中線";
   static constexpr const wchar_t *Settings_Label_RightButtonDragZoom =
       L"右鍵拖曳縮放";
+  static constexpr const wchar_t *Settings_Label_WheelZoomSpeed = L"滾輪縮放速度";
+  static constexpr const wchar_t *Settings_Label_RightDragZoomSpeed = L"右鍵拖曳縮放速度";
+  static constexpr const wchar_t *OSD_WheelZoomSpeed = L"縮放速度: ";
+  static constexpr const wchar_t *Help_Action_AdjustZoomSpeed = L"調節縮放速度";
+  static constexpr const wchar_t *Help_Action_LockWindowZoom = L"臨時鎖定視窗縮放";
   static constexpr const wchar_t *Settings_Label_InvertButtons = L"反轉側鍵";
   static constexpr const wchar_t *Settings_Label_ZoomModeIn = L"放大插值演算法";
   static constexpr const wchar_t *Settings_Label_ZoomModeOut =
@@ -2292,6 +2312,11 @@ struct JA {
       L"マウス中心でウィンドウを拡大";
   static constexpr const wchar_t *Settings_Label_RightButtonDragZoom =
       L"右ドラッグでズーム";
+  static constexpr const wchar_t *Settings_Label_WheelZoomSpeed = L"ホイールズーム速度";
+  static constexpr const wchar_t *Settings_Label_RightDragZoomSpeed = L"右ドラッグズーム速度";
+  static constexpr const wchar_t *OSD_WheelZoomSpeed = L"ズーム速度: ";
+  static constexpr const wchar_t *Help_Action_AdjustZoomSpeed = L"ズーム速度を調整";
+  static constexpr const wchar_t *Help_Action_LockWindowZoom = L"ウィンドウのズームを一時的にロック";
   static constexpr const wchar_t *Settings_Label_InvertButtons =
       L"サイドボタン反転";
   static constexpr const wchar_t *Settings_Label_ZoomModeIn =
@@ -2889,6 +2914,11 @@ struct RU {
       L"Масштабировать окно от позиции мыши";
   static constexpr const wchar_t *Settings_Label_RightButtonDragZoom =
       L"Масштаб правой кнопкой мыши";
+  static constexpr const wchar_t *Settings_Label_WheelZoomSpeed = L"Скорость зума колесиком";
+  static constexpr const wchar_t *Settings_Label_RightDragZoomSpeed = L"Скорость зума правой кнопкой";
+  static constexpr const wchar_t *OSD_WheelZoomSpeed = L"Скорость зума: ";
+  static constexpr const wchar_t *Help_Action_AdjustZoomSpeed = L"Настроить скорость зума";
+  static constexpr const wchar_t *Help_Action_LockWindowZoom = L"Временно заблокировать масштаб окна";
   static constexpr const wchar_t *Settings_Label_InvertButtons =
       L"Инвертировать действие боковых кнопок";
   static constexpr const wchar_t *Settings_Label_ZoomModeIn =
@@ -3453,6 +3483,11 @@ struct DE {
       L"Fensterzoom am Mauszeiger ausrichten";
   static constexpr const wchar_t *Settings_Label_RightButtonDragZoom =
       L"Zoom mit Rechtsziehen";
+  static constexpr const wchar_t *Settings_Label_WheelZoomSpeed = L"Mausrad-Zoomgeschwindigkeit";
+  static constexpr const wchar_t *Settings_Label_RightDragZoomSpeed = L"Rechtszieh-Zoomgeschwindigkeit";
+  static constexpr const wchar_t *OSD_WheelZoomSpeed = L"Zoomgeschwindigkeit: ";
+  static constexpr const wchar_t *Help_Action_AdjustZoomSpeed = L"Zoomgeschwindigkeit anpassen";
+  static constexpr const wchar_t *Help_Action_LockWindowZoom = L"Fensterzoom vorübergehend sperren";
   static constexpr const wchar_t *Settings_Label_InvertButtons =
       L"Seitentasten invertieren";
   static constexpr const wchar_t *Settings_Label_ZoomModeIn =
@@ -4010,6 +4045,11 @@ struct ES {
       L"Zoom de ventana anclado al raton";
   static constexpr const wchar_t *Settings_Label_RightButtonDragZoom =
       L"Zoom con arrastre derecho";
+  static constexpr const wchar_t *Settings_Label_WheelZoomSpeed = L"Velocidad de zoom con rueda";
+  static constexpr const wchar_t *Settings_Label_RightDragZoomSpeed = L"Velocidad de zoom con arrastre derecho";
+  static constexpr const wchar_t *OSD_WheelZoomSpeed = L"Velocidad de zoom: ";
+  static constexpr const wchar_t *Help_Action_AdjustZoomSpeed = L"Ajustar velocidad de zoom";
+  static constexpr const wchar_t *Help_Action_LockWindowZoom = L"Bloquear temporalmente el zoom de la ventana";
   static constexpr const wchar_t *Settings_Label_InvertButtons =
       L"Invertir botones laterales";
   static constexpr const wchar_t *Settings_Label_ZoomModeIn =
@@ -4501,6 +4541,11 @@ template <typename T> void ApplyT() {
   Settings_Label_ZoomSnapDamping = T::Settings_Label_ZoomSnapDamping;
   Settings_Label_MouseAnchorZoom = T::Settings_Label_MouseAnchorZoom;
   Settings_Label_RightButtonDragZoom = T::Settings_Label_RightButtonDragZoom;
+  Settings_Label_WheelZoomSpeed = T::Settings_Label_WheelZoomSpeed;
+  Settings_Label_RightDragZoomSpeed = T::Settings_Label_RightDragZoomSpeed;
+  OSD_WheelZoomSpeed = T::OSD_WheelZoomSpeed;
+  Help_Action_AdjustZoomSpeed = T::Help_Action_AdjustZoomSpeed;
+  Help_Action_LockWindowZoom = T::Help_Action_LockWindowZoom;
   Settings_Label_InvertButtons = T::Settings_Label_InvertButtons;
   Settings_Label_ZoomModeIn = T::Settings_Label_ZoomModeIn;
   Settings_Label_ZoomModeOut = T::Settings_Label_ZoomModeOut;

--- a/QuickView/AppStrings.h
+++ b/QuickView/AppStrings.h
@@ -265,6 +265,11 @@ namespace AppStrings {
     extern const wchar_t* Settings_Label_ZoomSnapDamping; // New
     extern const wchar_t* Settings_Label_MouseAnchorZoom;
     extern const wchar_t* Settings_Label_RightButtonDragZoom;
+    extern const wchar_t* Settings_Label_WheelZoomSpeed;
+    extern const wchar_t* Settings_Label_RightDragZoomSpeed;
+    extern const wchar_t* OSD_WheelZoomSpeed;
+    extern const wchar_t* Help_Action_AdjustZoomSpeed;
+    extern const wchar_t* Help_Action_LockWindowZoom;
     extern const wchar_t* Settings_Label_InvertButtons;
     extern const wchar_t* Settings_Label_ZoomModeIn;
     extern const wchar_t* Settings_Label_ZoomModeOut;

--- a/QuickView/EditState.h
+++ b/QuickView/EditState.h
@@ -192,6 +192,8 @@ struct AppConfig {
     bool EnableZoomSnapDamping = true;
     bool MouseAnchoredWindowZoom = false; // Expand window toward the mouse position during zoom
     bool RightButtonDragZoom = true;      // Hold right button and drag vertically to zoom
+    float WheelZoomSpeed = 10.0f;         // 5.0f to 50.0f (percentage)
+    float RightDragZoomSpeed = 1.0f;      // 0.1f to 3.0f (multiplier)
     MouseAction LeftDragAction = MouseAction::WindowDrag;
     MouseAction MiddleDragAction = MouseAction::PanImage;
     MouseAction MiddleClickAction = MouseAction::ExitApp;

--- a/QuickView/HelpOverlay.cpp
+++ b/QuickView/HelpOverlay.cpp
@@ -97,7 +97,8 @@ void HelpOverlay::RebuildList() {
     m_items.push_back({ false, L"Home / End", AppStrings::Help_Item_FirstLast });
     bool wheelPrimaryNavigate = (g_config.WheelActionMode == 1);
     m_items.push_back({ false, AppStrings::Help_Mouse_Wheel, wheelPrimaryNavigate ? AppStrings::Help_Action_NextPrev : AppStrings::Help_Action_Zoom });
-    m_items.push_back({ false, L"Ctrl + Scroll", wheelPrimaryNavigate ? AppStrings::Help_Action_Zoom : AppStrings::Help_Action_NextPrev });
+    m_items.push_back({ false, L"Ctrl + Scroll", AppStrings::Help_Action_LockWindowZoom });
+    m_items.push_back({ false, L"Alt + Scroll", AppStrings::Help_Action_AdjustZoomSpeed });
     m_items.push_back({ false, AppStrings::Help_Mouse_RightVerticalDrag, AppStrings::Help_Action_Zoom });
     m_items.push_back({ false, AppStrings::Help_Mouse_Right, AppStrings::Help_Action_ContextMenu });
     m_items.push_back({ false, AppStrings::Settings_Label_LeftDrag, AppStrings::Help_Action_MoveWindow });

--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -1600,6 +1600,8 @@ void SettingsOverlay::BuildMenu() {
     tabControl.items.push_back({ AppStrings::Settings_Label_ZoomSnapDamping, OptionType::Toggle, &g_config.EnableZoomSnapDamping });
     tabControl.items.push_back({ AppStrings::Settings_Label_MouseAnchorZoom, OptionType::Toggle, &g_config.MouseAnchoredWindowZoom });
     tabControl.items.push_back({ AppStrings::Settings_Label_RightButtonDragZoom, OptionType::Toggle, &g_config.RightButtonDragZoom });
+    tabControl.items.push_back({ AppStrings::Settings_Label_RightDragZoomSpeed, OptionType::Slider, nullptr, nullptr, nullptr, nullptr, 0.1f, 3.0f, {}, &g_config.RightDragZoomSpeed, L"%.1fx" });
+    tabControl.items.push_back({ AppStrings::Settings_Label_WheelZoomSpeed, OptionType::Slider, nullptr, nullptr, nullptr, nullptr, 5.0f, 50.0f, {}, &g_config.WheelZoomSpeed, L"%.0f%%" });
     tabControl.items.push_back({ AppStrings::Settings_Label_InvertButtons, OptionType::Toggle, &g_config.InvertXButton });
     
     // Left Drag: {Window=0, Pan=1} -> {WindowDrag=1, PanImage=2}

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -1106,13 +1106,14 @@ static bool g_hasRightDragZoomStartViews = false;
 static D2D1_SIZE_F GetOrientedSize(const ImageResource& res, int exifOrientation);
 
 static float ComputeZoomStep(float wheelDelta) {
-    const float unit = (wheelDelta >= 0.0f) ? 1.1f : (1.0f / 1.1f);
+    float factor = 1.0f + (g_config.WheelZoomSpeed / 100.0f);
+    const float unit = (wheelDelta >= 0.0f) ? factor : (1.0f / factor);
     const float count = (std::max)(1.0f, fabsf(wheelDelta));
     return powf(unit, count);
 }
 
 static float ComputeZoomMultiplier(float delta, bool fineInterval) {
-    float step = fineInterval ? 0.01f : 0.1f;
+    float step = fineInterval ? 0.01f : (g_config.WheelZoomSpeed / 100.0f);
     if (delta > 0.0f) return 1.0f + step * delta;
     return 1.0f / (1.0f + step * fabsf(delta));
 }
@@ -3458,10 +3459,10 @@ static float CalculateTargetZoom(HWND hwnd, float delta, bool isFineInterval = f
     }
 
     // 5. Calculate Zoom Factor
-    // Mouse: Delta is usually +/- 1.0 (after div 120). Factor 1.1 (= 10%)
+    // Mouse: Delta is usually +/- 1.0 (after div 120). Factor WheelZoomSpeed (default 10%)
     // Keyboard: Delta is +/- 1.0. 
     // Fine Interval (Ctrl): 1%
-    float step = isFineInterval ? 0.01f : 0.1f;
+    float step = isFineInterval ? 0.01f : (g_config.WheelZoomSpeed / 100.0f);
     
     // Support non-integer delta (e.g. precision touchpad)
     // Formula: Scale * (1 + step * delta) 
@@ -4512,6 +4513,8 @@ void SaveConfig() {
     WritePrivateProfileStringW(L"Controls", L"EnableZoomSnapDamping", g_config.EnableZoomSnapDamping ? L"1" : L"0", iniPath.c_str());
     WritePrivateProfileStringW(L"Controls", L"MouseAnchoredWindowZoom", g_config.MouseAnchoredWindowZoom ? L"1" : L"0", iniPath.c_str());
     WritePrivateProfileStringW(L"Controls", L"RightButtonDragZoom", g_config.RightButtonDragZoom ? L"1" : L"0", iniPath.c_str());
+    WritePrivateProfileStringW(L"Controls", L"WheelZoomSpeed", std::to_wstring(g_config.WheelZoomSpeed).c_str(), iniPath.c_str());
+    WritePrivateProfileStringW(L"Controls", L"RightDragZoomSpeed", std::to_wstring(g_config.RightDragZoomSpeed).c_str(), iniPath.c_str());
     WritePrivateProfileStringW(L"Controls", L"LeftDragAction", std::to_wstring((int)g_config.LeftDragAction).c_str(), iniPath.c_str());
     WritePrivateProfileStringW(L"Controls", L"MiddleDragAction", std::to_wstring((int)g_config.MiddleDragAction).c_str(), iniPath.c_str());
     WritePrivateProfileStringW(L"Controls", L"MiddleClickAction", std::to_wstring((int)g_config.MiddleClickAction).c_str(), iniPath.c_str());
@@ -4733,6 +4736,11 @@ void LoadConfig() {
     g_config.EnableZoomSnapDamping = GetPrivateProfileIntW(L"Controls", L"EnableZoomSnapDamping", 1, iniPath.c_str()) != 0;
     g_config.MouseAnchoredWindowZoom = GetPrivateProfileIntW(L"Controls", L"MouseAnchoredWindowZoom", 0, iniPath.c_str()) != 0;
     g_config.RightButtonDragZoom = GetPrivateProfileIntW(L"Controls", L"RightButtonDragZoom", 1, iniPath.c_str()) != 0;
+    wchar_t buf[64];
+    GetPrivateProfileStringW(L"Controls", L"WheelZoomSpeed", L"10.0", buf, 64, iniPath.c_str());
+    g_config.WheelZoomSpeed = std::max(5.0f, std::min(50.0f, (float)_wtof(buf)));
+    GetPrivateProfileStringW(L"Controls", L"RightDragZoomSpeed", L"1.0", buf, 64, iniPath.c_str());
+    g_config.RightDragZoomSpeed = std::max(0.1f, std::min(3.0f, (float)_wtof(buf)));
     g_config.LeftDragAction = (MouseAction)GetPrivateProfileIntW(L"Controls", L"LeftDragAction", (int)MouseAction::WindowDrag, iniPath.c_str());
     g_config.MiddleDragAction = (MouseAction)GetPrivateProfileIntW(L"Controls", L"MiddleDragAction", (int)MouseAction::PanImage, iniPath.c_str());
     g_config.MiddleClickAction = (MouseAction)GetPrivateProfileIntW(L"Controls", L"MiddleClickAction", (int)MouseAction::ExitApp, iniPath.c_str());
@@ -7075,7 +7083,7 @@ SKIP_EDGE_NAV:;
                  POINT cursorPos{};
                  GetCursorPos(&cursorPos);
                  const float totalDy = (float)(cursorPos.y - g_viewState.RightDragZoomStartScreenPos.y);
-                 const float dragSteps = -totalDy / (48.0f * (std::max)(0.75f, g_uiScale));
+                 const float dragSteps = (-totalDy * g_config.RightDragZoomSpeed) / (48.0f * (std::max)(0.75f, g_uiScale));
                  float multiplier = 1.0f;
                  if (dragSteps > 0.0f) multiplier = 1.0f + 0.1f * dragSteps;
                  else if (dragSteps < 0.0f) multiplier = 1.0f / (1.0f + 0.1f * fabsf(dragSteps));
@@ -7092,7 +7100,7 @@ SKIP_EDGE_NAV:;
                  POINT cursorPos{};
                  GetCursorPos(&cursorPos);
                  const float totalDy = (float)(cursorPos.y - g_viewState.RightDragZoomStartScreenPos.y);
-                 const float dragSteps = -totalDy / (kPixelsPerStep * (std::max)(0.75f, g_uiScale));
+                 const float dragSteps = (-totalDy * g_config.RightDragZoomSpeed) / (kPixelsPerStep * (std::max)(0.75f, g_uiScale));
                  if (fabsf(dragSteps) > 0.0001f) {
                      g_viewState.IsInteracting = true;
                      SetTimer(hwnd, IDT_INTERACTION, 150, nullptr);
@@ -8245,6 +8253,18 @@ SKIP_EDGE_NAV:;
         if (g_config.InvertWheel) delta = -delta;
 
         bool isCtrl = (GET_KEYSTATE_WPARAM(wParam) & MK_CONTROL) != 0;
+        bool isAlt = (GET_KEYSTATE_WPARAM(wParam) & MK_ALT) != 0;
+
+        if (isAlt) {
+            g_config.WheelZoomSpeed += (delta > 0) ? 5.0f : -5.0f;
+            g_config.WheelZoomSpeed = std::max(5.0f, std::min(50.0f, g_config.WheelZoomSpeed));
+            SaveConfig();
+            wchar_t speedBuf[64];
+            swprintf_s(speedBuf, L"%s%.0f%%", AppStrings::OSD_WheelZoomSpeed, g_config.WheelZoomSpeed);
+            g_osd.Show(hwnd, speedBuf, false);
+            return 0;
+        }
+
         bool wheelPrimaryNavigate = (g_config.WheelActionMode == 1);
         bool shouldNavigate = wheelPrimaryNavigate ? !isCtrl : isCtrl;
 
@@ -8287,7 +8307,7 @@ SKIP_EDGE_NAV:;
 
         // Use Centralized Helper
         POINT mousePt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
-        PerformSmartZoom(hwnd, newTotalScale, &mousePt, false, true);
+        PerformSmartZoom(hwnd, newTotalScale, &mousePt, isCtrl, true);
         RequestRepaint(PaintLayer::Dynamic);
 
              


### PR DESCRIPTION
- Added temporary window scale lock by using Ctrl + Mouse Wheel (`PerformSmartZoom` uses `isCtrl` flag to lock resize).
- Added Alt + Mouse Wheel to change the mouse wheel zoom step size, adjusting WheelZoomSpeed from 5% to 50% dynamically, complete with OSD notification (e.g. `Zoom Speed: 15%`).
- Added Right Drag Zoom Speed and Wheel Zoom Speed options into the AppConfig state and SettingsOverlay Controls tab.
- Replaced hardcoded constants for wheel/drag zooming in `CalculateTargetZoom`, `ComputeZoomMultiplier`, and `WM_RBUTTONDOWN` dragging block with dynamic parameters from Config.
- Added matching translation strings in `AppStrings.cpp`/`h` across EN, ZH, ZHTW, JA, RU, DE, ES.
- Updated the Help menu mappings in `HelpOverlay.cpp` for the Ctrl+Scroll and Alt+Scroll combos.

---
*PR created automatically by Jules for task [2706835492996457998](https://jules.google.com/task/2706835492996457998) started by @justnullname*