### PR TITLE
Add restore initial size functionality for Zoom/Fit hotkeys and double-click

### DIFF
--- a/QuickView/AppStrings.cpp
+++ b/QuickView/AppStrings.cpp
@@ -953,7 +953,7 @@ struct EN {
   static constexpr const wchar_t *Help_Action_NextPrev = L"Next/Prev Image";
   static constexpr const wchar_t *Help_Action_Zoom = L"Zoom";
   static constexpr const wchar_t *Help_Action_SmartZoom =
-      L"Smart Zoom (100% / Fit)";
+      L"Smart Zoom (100% / Fit / Restore)";
   static constexpr const wchar_t *Help_Desc_Copy = L"Copy Image";
   static constexpr const wchar_t *Help_Desc_Edit = L"Edit";
 
@@ -1323,7 +1323,7 @@ struct CN {
   static constexpr const wchar_t *Help_Action_NextPrev = L"切换图片";
   static constexpr const wchar_t *Help_Action_Zoom = L"缩放";
   static constexpr const wchar_t *Help_Action_SmartZoom =
-      L"智能缩放 (100% / 适应窗口)";
+      L"智能缩放 (100% / 适应窗口 / 恢复)";
 
   // Context Menu
   static constexpr const wchar_t *Context_Open = L"打开...\tCtrl+O";
@@ -1934,7 +1934,7 @@ struct TW {
   static constexpr const wchar_t *Help_Action_NextPrev = L"切換圖片";
   static constexpr const wchar_t *Help_Action_Zoom = L"縮放";
   static constexpr const wchar_t *Help_Action_SmartZoom =
-      L"智能縮放 (100% / 適應窗口)";
+      L"智能縮放 (100% / 適應窗口 / 恢復)";
   static constexpr const wchar_t *Help_Desc_Copy = L"復制圖像";
   static constexpr const wchar_t *Help_Desc_Edit = L"編輯";
 
@@ -2458,7 +2458,7 @@ struct JA {
   static constexpr const wchar_t *Help_Action_NextPrev = L"次/前の画像";
   static constexpr const wchar_t *Help_Action_Zoom = L"ズーム";
   static constexpr const wchar_t *Help_Action_SmartZoom =
-      L"スマートズーム (100% / ウィンドウに合わせる)";
+      L"スマートズーム (100% / ウィンドウに合わせる / 復元)";
   static constexpr const wchar_t *Help_Desc_Copy = L"Copy Image";
   static constexpr const wchar_t *Help_Desc_Edit = L"Edit";
 
@@ -3087,7 +3087,7 @@ struct RU {
   static constexpr const wchar_t *Help_Action_NextPrev = L"След./Пред.";
   static constexpr const wchar_t *Help_Action_Zoom = L"Масштаб";
   static constexpr const wchar_t *Help_Action_SmartZoom =
-      L"Умный масштаб (100% / По размеру)";
+      L"Умный масштаб (100% / По размеру / Восстановить)";
   static constexpr const wchar_t *Help_Desc_Copy = L"Скопировать изображение";
   static constexpr const wchar_t *Help_Desc_Edit = L"Изменить";
 
@@ -3629,7 +3629,7 @@ struct DE {
   static constexpr const wchar_t *Help_Action_NextPrev = L"Weiter/Zurück";
   static constexpr const wchar_t *Help_Action_Zoom = L"Zoom";
   static constexpr const wchar_t *Help_Action_SmartZoom =
-      L"Smart-Zoom (100% / Anpassen)";
+      L"Smart-Zoom (100% / Anpassen / Wiederherstellen)";
   static constexpr const wchar_t *Help_Desc_Copy = L"Copy Image";
   static constexpr const wchar_t *Help_Desc_Edit = L"Edit";
 
@@ -4200,7 +4200,7 @@ struct ES {
   static constexpr const wchar_t *Help_Action_NextPrev = L"Sig./Ant.";
   static constexpr const wchar_t *Help_Action_Zoom = L"Zoom";
   static constexpr const wchar_t *Help_Action_SmartZoom =
-      L"Zoom inteligente (100% / Ajustar)";
+      L"Zoom inteligente (100% / Ajustar / Restaurar)";
   static constexpr const wchar_t *Help_Desc_Copy = L"Copy Image";
   static constexpr const wchar_t *Help_Desc_Edit = L"Edit";
 

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -3234,6 +3234,46 @@ static void ToggleCompareHUD(HWND hwnd, int targetMode) {
 
 static RECT s_restoredWindowRect = { 0 };
 
+static float GetCurrentRealScale(HWND hwnd) {
+    if (!g_imageResource) return 1.0f;
+    D2D1_SIZE_F effSize = GetVisualImageSize();
+    float imgW = effSize.width;
+    float imgH = effSize.height;
+    if (imgW <= 0 || imgH <= 0) return 1.0f;
+
+    float originalW = imgW;
+    float originalH = imgH;
+    if (g_currentMetadata.Width > 0 && g_currentMetadata.Height > 0) {
+        originalW = (float)g_currentMetadata.Width;
+        originalH = (float)g_currentMetadata.Height;
+        bool manualSwap = (g_editState.TotalRotation % 180 != 0);
+        if (manualSwap) std::swap(originalW, originalH);
+    }
+
+    RECT rcClient; GetClientRect(hwnd, &rcClient);
+    float winW = (float)(rcClient.right - rcClient.left);
+    float winH = (float)(rcClient.bottom - rcClient.top);
+
+    float fitScale = (std::min)(winW / imgW, winH / imgH);
+    float totalScale = fitScale * g_viewState.Zoom;
+    return totalScale * (imgW / originalW); // Real pixel scale
+}
+
+static void PerformRestoreWindow(HWND hwnd) {
+    if (s_restoredWindowRect.right > s_restoredWindowRect.left && !IsZoomed(hwnd) && !g_isFullScreen) {
+        int rW = s_restoredWindowRect.right - s_restoredWindowRect.left;
+        int rH = s_restoredWindowRect.bottom - s_restoredWindowRect.top;
+        SetWindowPos(hwnd, nullptr, s_restoredWindowRect.left, s_restoredWindowRect.top, rW, rH, SWP_NOZORDER | SWP_NOACTIVATE);
+        g_viewState.Zoom = 1.0f;
+        g_viewState.PanX = 0;
+        g_viewState.PanY = 0;
+        g_osd.Show(hwnd, AppStrings::OSD_Restored, false, false, D2D1::ColorF(D2D1::ColorF::White));
+        RequestRepaint(PaintLayer::All);
+
+        s_restoredWindowRect = { 0 };
+    }
+}
+
 // Inlined Logic to avoid dependency on local lambdas
 static void PerformCompareZoom100(HWND hwnd) {
     if (!IsCompareModeActive()) return;
@@ -5102,6 +5142,7 @@ void AdjustWindowForOverlay(HWND hwnd, bool isClosed) {
 }
 
 void AdjustWindowToImage(HWND hwnd) {
+    s_restoredWindowRect = { 0 }; // Clear restored rect so new image sets new initial size
     if (!g_imageResource) return;
     if (g_runtime.LockWindowSize) return;  // Don't auto-resize when locked
     if (g_settingsOverlay.IsVisible()) return; // Don't resize if Settings is open (prevents jitter)
@@ -6345,6 +6386,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
         return 0;
     }
     case WM_EXITSIZEMOVE: {
+        s_restoredWindowRect = { 0 }; // Clear restored rect so new size is treated as initial
         // Interactive resize/move ended - sync composition state immediately
         if (g_compEngine && g_compEngine->IsInitialized()) {
             RECT rc; GetClientRect(hwnd, &rc);
@@ -7317,28 +7359,7 @@ SKIP_EDGE_NAV:;
         }
 
         if (g_imageResource) {
-            // [Bug #19] Smart 3-Way Toggle for Large Images
-            D2D1_SIZE_F effSize = GetVisualImageSize();
-            float imgW = effSize.width;
-            float imgH = effSize.height;
-            
-            float originalW = imgW;
-            float originalH = imgH;
-            if (g_currentMetadata.Width > 0 && g_currentMetadata.Height > 0) {
-                originalW = (float)g_currentMetadata.Width;
-                originalH = (float)g_currentMetadata.Height;
-                bool manualSwap = (g_editState.TotalRotation % 180 != 0);
-                if (manualSwap) std::swap(originalW, originalH);
-            }
-
-            RECT rcClient; GetClientRect(hwnd, &rcClient);
-            float winW = (float)(rcClient.right - rcClient.left);
-            float winH = (float)(rcClient.bottom - rcClient.top);
-            
-            float fitScale = std::min(winW / imgW, winH / imgH);
-            float totalScale = fitScale * g_viewState.Zoom;
-            float currentRealScale = totalScale * (imgW / originalW); // Real pixel scale
-            
+            float currentRealScale = GetCurrentRealScale(hwnd);
             bool is100Percent = (fabsf(currentRealScale - 1.0f) < 0.05f);
 
             HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
@@ -7352,39 +7373,43 @@ SKIP_EDGE_NAV:;
 
             bool isWindowMaximizedOrFull = (winWidth >= maxW - 2 || winHeight >= maxH - 2) || IsZoomed(hwnd) || g_isFullScreen;
             
-            // Is it a large image? (Original size is close to or larger than screen)
+            float originalW = g_currentMetadata.Width > 0 ? (float)g_currentMetadata.Width : GetVisualImageSize().width;
+            float originalH = g_currentMetadata.Height > 0 ? (float)g_currentMetadata.Height : GetVisualImageSize().height;
+            if (g_currentMetadata.Width > 0 && g_currentMetadata.Height > 0) {
+                bool manualSwap = (g_editState.TotalRotation % 180 != 0);
+                if (manualSwap) std::swap(originalW, originalH);
+            }
             bool isLargeImage = (originalW >= maxW - 100 || originalH >= maxH - 100);
 
             if (isLargeImage) {
                 if (is100Percent) {
-                    // State 3 -> State 1 (or State 2 if in fixed mode): At 100%.
                     if (isWindowMaximizedOrFull) {
-                        PerformZoomFit(hwnd); // Dual-mode for maximized/fullscreen
+                        PerformZoomFit(hwnd);
                     } else if (s_restoredWindowRect.right > s_restoredWindowRect.left) {
-                        int rW = s_restoredWindowRect.right - s_restoredWindowRect.left;
-                        int rH = s_restoredWindowRect.bottom - s_restoredWindowRect.top;
-                        SetWindowPos(hwnd, nullptr, s_restoredWindowRect.left, s_restoredWindowRect.top, rW, rH, SWP_NOZORDER | SWP_NOACTIVATE);
-                        g_viewState.Zoom = 1.0f; // Let D2D fit it inside
-                        g_osd.Show(hwnd, AppStrings::OSD_ZoomFit, false, false, D2D1::ColorF(D2D1::ColorF::White));
-                        RequestRepaint(PaintLayer::All);
+                        PerformRestoreWindow(hwnd);
                     } else {
-                        // Fallback: 85% tight wrap (perfectly hugs the image without empty margins)
                         PerformZoomFit(hwnd, 0.85f);
                     }
                 } else if (isWindowMaximizedOrFull) {
-                    // State 2 -> State 3: Fit Screen but not 100% -> Go 100%
                     PerformZoom100(hwnd);
                 } else {
-                    // State 1 -> State 2: Initial Size -> Fit Screen
-                    GetWindowRect(hwnd, &s_restoredWindowRect);
+                    if (s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
                     PerformZoomFit(hwnd, 1.0f); 
                 }
             } else {
-                // Small image: simple 2-state toggle (100% <-> Fit)
                 if (is100Percent) {
-                    PerformZoomFit(hwnd, 1.0f);
+                    if (isWindowMaximizedOrFull && s_restoredWindowRect.right > s_restoredWindowRect.left) {
+                        PerformRestoreWindow(hwnd);
+                    } else {
+                        if (s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
+                        PerformZoomFit(hwnd, 1.0f);
+                    }
                 } else {
-                    PerformZoom100(hwnd);
+                    if (s_restoredWindowRect.right > s_restoredWindowRect.left) {
+                        PerformRestoreWindow(hwnd);
+                    } else {
+                        PerformZoom100(hwnd);
+                    }
                 }
             }
         }
@@ -8649,15 +8674,44 @@ SKIP_EDGE_NAV:;
         case 'V': PerformTransform(hwnd, TransformType::FlipVertical); break;
         
         // Zoom
-        case '1': case 'Z': case VK_NUMPAD1: // 100% Original size
-            if (IsCompareModeActive()) PerformCompareZoom100(hwnd);
-            else PerformZoom100(hwnd);
+        case '1': case 'Z': case VK_NUMPAD1: { // 100% Original size
+            if (IsCompareModeActive()) {
+                PerformCompareZoom100(hwnd);
+            } else if (g_imageResource) {
+                float currentRealScale = GetCurrentRealScale(hwnd);
+                bool is100Percent = (fabsf(currentRealScale - 1.0f) < 0.05f);
+                if (is100Percent && s_restoredWindowRect.right > s_restoredWindowRect.left) {
+                    PerformRestoreWindow(hwnd);
+                } else {
+                    if (s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
+                    PerformZoom100(hwnd);
+                }
+            }
             break;
+        }
             
-        case '0': case 'F': case VK_NUMPAD0: // Fit to Screen (Best Fit)
-            if (IsCompareModeActive()) PerformCompareZoomFit(hwnd);
-            else PerformZoomFit(hwnd);
+        case '0': case 'F': case VK_NUMPAD0: { // Fit to Screen (Best Fit)
+            if (IsCompareModeActive()) {
+                PerformCompareZoomFit(hwnd);
+            } else if (g_imageResource) {
+                HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+                MONITORINFO mi = { sizeof(mi) }; GetMonitorInfoW(hMon, &mi);
+                int maxW = mi.rcWork.right - mi.rcWork.left;
+                int maxH = mi.rcWork.bottom - mi.rcWork.top;
+                RECT rcWin; GetWindowRect(hwnd, &rcWin);
+                int winWidth = rcWin.right - rcWin.left;
+                int winHeight = rcWin.bottom - rcWin.top;
+                bool isWindowMaximizedOrFull = (winWidth >= maxW - 2 || winHeight >= maxH - 2) || IsZoomed(hwnd) || g_isFullScreen;
+
+                if (isWindowMaximizedOrFull && s_restoredWindowRect.right > s_restoredWindowRect.left) {
+                    PerformRestoreWindow(hwnd);
+                } else {
+                    if (s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
+                    PerformZoomFit(hwnd);
+                }
+            }
             break;
+        }
 
         case VK_ADD: case VK_OEM_PLUS: // Zoom In
         case VK_SUBTRACT: case VK_OEM_MINUS: { // Zoom Out

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -7371,45 +7371,33 @@ SKIP_EDGE_NAV:;
             int winWidth = rcWin.right - rcWin.left;
             int winHeight = rcWin.bottom - rcWin.top;
 
-            bool isWindowMaximizedOrFull = (winWidth >= maxW - 2 || winHeight >= maxH - 2) || IsZoomed(hwnd) || g_isFullScreen;
-            
-            float originalW = g_currentMetadata.Width > 0 ? (float)g_currentMetadata.Width : GetVisualImageSize().width;
-            float originalH = g_currentMetadata.Height > 0 ? (float)g_currentMetadata.Height : GetVisualImageSize().height;
-            if (g_currentMetadata.Width > 0 && g_currentMetadata.Height > 0) {
-                bool manualSwap = (g_editState.TotalRotation % 180 != 0);
-                if (manualSwap) std::swap(originalW, originalH);
-            }
-            bool isLargeImage = (originalW >= maxW - 100 || originalH >= maxH - 100);
+            bool isMaximizedOrFullscreen = IsZoomed(hwnd) || g_isFullScreen;
+            bool isFitWindow = (winWidth >= maxW - 2 || winHeight >= maxH - 2) || isMaximizedOrFullscreen;
 
-            if (isLargeImage) {
+            if (isMaximizedOrFullscreen) {
+                // In fullscreen/maximized, ONLY toggle between 100% and Fit. No restoring window size.
                 if (is100Percent) {
-                    if (isWindowMaximizedOrFull) {
-                        PerformZoomFit(hwnd);
-                    } else if (s_restoredWindowRect.right > s_restoredWindowRect.left) {
-                        PerformRestoreWindow(hwnd);
-                    } else {
-                        PerformZoomFit(hwnd, 0.85f);
-                    }
-                } else if (isWindowMaximizedOrFull) {
-                    PerformZoom100(hwnd);
+                    PerformZoomFit(hwnd);
                 } else {
-                    if (s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
-                    PerformZoomFit(hwnd, 1.0f); 
+                    PerformZoom100(hwnd);
                 }
             } else {
+                // Windowed mode 3-state toggle: Initial Size (Restore) -> Fit -> 100% -> Initial Size...
                 if (is100Percent) {
-                    if (isWindowMaximizedOrFull && s_restoredWindowRect.right > s_restoredWindowRect.left) {
-                        PerformRestoreWindow(hwnd);
-                    } else {
-                        if (s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
-                        PerformZoomFit(hwnd, 1.0f);
-                    }
-                } else {
+                    // Current is 100%. Next should be Restore (or Fit if no restore point).
                     if (s_restoredWindowRect.right > s_restoredWindowRect.left) {
                         PerformRestoreWindow(hwnd);
                     } else {
-                        PerformZoom100(hwnd);
+                        GetWindowRect(hwnd, &s_restoredWindowRect);
+                        PerformZoomFit(hwnd, 1.0f);
                     }
+                } else if (isFitWindow) {
+                    // Current is Fit. Next should be 100%.
+                    PerformZoom100(hwnd);
+                } else {
+                    // Current is Initial Size. Next should be Fit.
+                    if (s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
+                    PerformZoomFit(hwnd, 1.0f);
                 }
             }
         }
@@ -8680,10 +8668,12 @@ SKIP_EDGE_NAV:;
             } else if (g_imageResource) {
                 float currentRealScale = GetCurrentRealScale(hwnd);
                 bool is100Percent = (fabsf(currentRealScale - 1.0f) < 0.05f);
-                if (is100Percent && s_restoredWindowRect.right > s_restoredWindowRect.left) {
+                bool isMaximizedOrFullscreen = IsZoomed(hwnd) || g_isFullScreen;
+
+                if (is100Percent && !isMaximizedOrFullscreen && s_restoredWindowRect.right > s_restoredWindowRect.left) {
                     PerformRestoreWindow(hwnd);
                 } else {
-                    if (s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
+                    if (!isMaximizedOrFullscreen && s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
                     PerformZoom100(hwnd);
                 }
             }
@@ -8701,12 +8691,14 @@ SKIP_EDGE_NAV:;
                 RECT rcWin; GetWindowRect(hwnd, &rcWin);
                 int winWidth = rcWin.right - rcWin.left;
                 int winHeight = rcWin.bottom - rcWin.top;
-                bool isWindowMaximizedOrFull = (winWidth >= maxW - 2 || winHeight >= maxH - 2) || IsZoomed(hwnd) || g_isFullScreen;
 
-                if (isWindowMaximizedOrFull && s_restoredWindowRect.right > s_restoredWindowRect.left) {
+                bool isMaximizedOrFullscreen = IsZoomed(hwnd) || g_isFullScreen;
+                bool isFitWindow = (winWidth >= maxW - 2 || winHeight >= maxH - 2) || isMaximizedOrFullscreen;
+
+                if (isFitWindow && !isMaximizedOrFullscreen && s_restoredWindowRect.right > s_restoredWindowRect.left) {
                     PerformRestoreWindow(hwnd);
                 } else {
-                    if (s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
+                    if (!isMaximizedOrFullscreen && s_restoredWindowRect.right == 0) GetWindowRect(hwnd, &s_restoredWindowRect);
                     PerformZoomFit(hwnd);
                 }
             }


### PR DESCRIPTION
Implemented a feature to restore the initial window size upon a second trigger of the zoom (1/Z), fit (0/F), and left-click double-click events, presenting an OSD prompt "Restored".

- **State Management:** Preserves the window's dimensions in `s_restoredWindowRect` prior to any automated resize induced by zoom or fit actions.
- **`GetCurrentRealScale` Helper:** Created to universally ascertain the accurate pixel scaling ratio.
- **`PerformRestoreWindow` Helper:** Added to coordinate resetting bounds, zoom/pan parameters, and flashing the localized OSD message.
- **Input Handling Refinement:** Enhanced the logic for `1`/`Z`, `0`/`F`, and `WM_LBUTTONDBLCLK` to detect current zoom states. If the target state is already active, the application will intelligently retreat to the original configuration instead of reapplying the zoom.
- **State Reset:** Automatically clears tracking data upon navigating to a new image (`AdjustWindowToImage`) or after a manual window resize (`WM_EXITSIZEMOVE`), guaranteeing contextual coherence.

---
*PR created automatically by Jules for task [11885056555935143061](https://jules.google.com/task/11885056555935143061) started by @justnullname*