### PR TITLE
Change cursor to hand when panning image

### DIFF
--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -6285,6 +6285,11 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
             }
         }
         
+        if (g_viewState.IsDragging) {
+            SetCursor(LoadCursor(nullptr, IDC_HAND));
+            return TRUE;
+        }
+
         // Default Client Cursor (Arrow) - Fixes stuck Wait cursor
         if (LOWORD(lParam) == HTCLIENT) {
             SetCursor(LoadCursor(nullptr, IDC_ARROW));
@@ -7470,6 +7475,7 @@ SKIP_EDGE_NAV:;
                 SetCapture(hwnd);
                 g_viewState.IsDragging = true;
                 g_viewState.IsInteracting = true;
+                SetCursor(LoadCursor(nullptr, IDC_HAND));
             } else {
                 g_viewState.IsDragging = false;
             }
@@ -7884,6 +7890,7 @@ SKIP_EDGE_NAV:;
                 g_viewState.IsDragging = true;
                 g_viewState.IsInteracting = true;  // Start interaction mode
                 g_viewState.LastMousePos = pt;
+                SetCursor(LoadCursor(nullptr, IDC_HAND));
             }
         }
         return 0;

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -6286,8 +6286,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
         }
         
         if (g_viewState.IsDragging) {
-            SetCursor(LoadCursor(nullptr, IDC_HAND));
-            return TRUE;
+          SetCursor(LoadCursor(nullptr, IDC_SIZEALL));
+          return TRUE;
         }
 
         // Default Client Cursor (Arrow) - Fixes stuck Wait cursor
@@ -7475,7 +7475,7 @@ SKIP_EDGE_NAV:;
                 SetCapture(hwnd);
                 g_viewState.IsDragging = true;
                 g_viewState.IsInteracting = true;
-                SetCursor(LoadCursor(nullptr, IDC_HAND));
+                SetCursor(LoadCursor(nullptr, IDC_SIZEALL));
             } else {
                 g_viewState.IsDragging = false;
             }
@@ -7890,7 +7890,7 @@ SKIP_EDGE_NAV:;
                 g_viewState.IsDragging = true;
                 g_viewState.IsInteracting = true;  // Start interaction mode
                 g_viewState.LastMousePos = pt;
-                SetCursor(LoadCursor(nullptr, IDC_HAND));
+                SetCursor(LoadCursor(nullptr, IDC_SIZEALL));
             }
         }
         return 0;


### PR DESCRIPTION
This commit adds a hand cursor that appears when the user clicks to pan an image. The cursor immediately updates on click (WM_MBUTTONDOWN, WM_LBUTTONDOWN) and remains a hand cursor while dragging by updating the WM_SETCURSOR handler.

---
*PR created automatically by Jules for task [14735072170816835997](https://jules.google.com/task/14735072170816835997) started by @justnullname*