### PR TITLE
Fix Smart Interpolation and Zoom Mode settings in single view

### DIFF
--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -1663,8 +1663,23 @@ void SettingsOverlay::BuildMenu() {
     tabImage.items.push_back({ AppStrings::Settings_Header_Render, OptionType::Header });
 
     // Zoom Mode
-    tabImage.items.push_back({ AppStrings::Settings_Label_ZoomModeIn, OptionType::ComboBox, nullptr, nullptr, BindEnum(&g_config.ZoomModeIn), nullptr, 0, 0, {AppStrings::Settings_Option_ZoomAuto, AppStrings::Settings_Option_Linear, AppStrings::Settings_Option_Nearest, AppStrings::Settings_Option_HighQualityCubic} });
-    tabImage.items.push_back({ AppStrings::Settings_Label_ZoomModeOut, OptionType::ComboBox, nullptr, nullptr, BindEnum(&g_config.ZoomModeOut), nullptr, 0, 0, {AppStrings::Settings_Option_ZoomAuto, AppStrings::Settings_Option_Linear, AppStrings::Settings_Option_Nearest, AppStrings::Settings_Option_HighQualityCubic} });
+    SettingsItem itemZoomIn = { AppStrings::Settings_Label_ZoomModeIn, OptionType::ComboBox, nullptr, nullptr, BindEnum(&g_config.ZoomModeIn), nullptr, 0, 0, {AppStrings::Settings_Option_ZoomAuto, AppStrings::Settings_Option_Linear, AppStrings::Settings_Option_Nearest, AppStrings::Settings_Option_HighQualityCubic} };
+    itemZoomIn.onChange = []() {
+        SaveConfig();
+        extern HWND g_mainHwnd;
+        extern void RefreshImageDisplay(HWND hwnd);
+        RefreshImageDisplay(g_mainHwnd);
+    };
+    tabImage.items.push_back(itemZoomIn);
+
+    SettingsItem itemZoomOut = { AppStrings::Settings_Label_ZoomModeOut, OptionType::ComboBox, nullptr, nullptr, BindEnum(&g_config.ZoomModeOut), nullptr, 0, 0, {AppStrings::Settings_Option_ZoomAuto, AppStrings::Settings_Option_Linear, AppStrings::Settings_Option_Nearest, AppStrings::Settings_Option_HighQualityCubic} };
+    itemZoomOut.onChange = []() {
+        SaveConfig();
+        extern HWND g_mainHwnd;
+        extern void RefreshImageDisplay(HWND hwnd);
+        RefreshImageDisplay(g_mainHwnd);
+    };
+    tabImage.items.push_back(itemZoomOut);
 
     tabImage.items.push_back({ AppStrings::Settings_Label_AutoRotate, OptionType::Toggle, &g_config.AutoRotate });
     

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -5560,6 +5560,9 @@ static void SyncDCompState(HWND hwnd, float winW, float winH, bool animate) {
                 g_compEngine->SetImageInterpolationMode(interpMode);
             } else {
                 g_compEngine->UpdateTransformMatrix(vs, winW, winH, displayZoom, displayPanX, displayPanY, animationDurationMs);
+
+                DCOMPOSITION_BITMAP_INTERPOLATION_MODE interpMode = GetOptimalDCompInterpolationMode(displayZoom, vs.VisualSize.width, vs.VisualSize.height);
+                g_compEngine->SetImageInterpolationMode(interpMode);
             }
         }
     } else {


### PR DESCRIPTION
Fixes two issues reported by the user:

1.  **Pixel Art Mode in Single View:** The issue occurred because Single View mode uses DirectComposition (`DComp`) for rendering, and while the interpolation mode was calculated, it was never actually applied to the DComp surface for bitmaps (it was only applied for SVGs). I updated `SyncDCompState` in `main.cpp` to correctly call `g_compEngine->SetImageInterpolationMode` for bitmaps, ensuring that "Nearest Neighbor" is respected when Pixel Art Mode is active.
2.  **Zoom Mode (In) Settings Delay:** The issue was that changing the Zoom Mode in the settings panel didn't trigger an immediate re-render. I updated `SettingsOverlay.cpp` to attach `onChange` callbacks to the "Zoom Mode (In)" and "Zoom Mode (Out)" dropdowns. Now, when you change the setting, it immediately calls `RefreshImageDisplay`, updating the view instantly.

---
*PR created automatically by Jules for task [18286316345225591235](https://jules.google.com/task/18286316345225591235) started by @justnullname*