### PR TITLE
feat: Add libplacebo Spline tone mapping algorithm for HDR

### DIFF
--- a/QuickView/AppStrings.cpp
+++ b/QuickView/AppStrings.cpp
@@ -281,6 +281,7 @@ const wchar_t *Settings_Label_HdrPeakNitsOverride = nullptr;
 const wchar_t *Settings_Tooltip_HdrPeakNitsOverride = nullptr;
 const wchar_t *Settings_Option_HdrPerceptual = nullptr;
 const wchar_t *Settings_Option_HdrColorimetric = nullptr;
+const wchar_t *Settings_Option_HdrSpline = nullptr;
 const wchar_t *Settings_Label_CmsFallback = nullptr;
 const wchar_t *Settings_Label_CustomProof = nullptr;
 const wchar_t *Context_SoftProofing = nullptr;
@@ -894,6 +895,7 @@ struct EN {
   static constexpr const wchar_t *Settings_Tooltip_HdrPeakNitsOverride = L"Set to 0 to use system detected brightness.";
   static constexpr const wchar_t *Settings_Option_HdrPerceptual = L"Perceptual";
   static constexpr const wchar_t *Settings_Option_HdrColorimetric = L"Colorimetric";
+  static constexpr const wchar_t *Settings_Option_HdrSpline = L"Spline (libplacebo)";
   static constexpr const wchar_t *Settings_Label_CmsFallback = L"Untagged Image Fallback";
   static constexpr const wchar_t *Settings_Label_CustomProof = L"Soft Proof Profile (.icc)";
   static constexpr const wchar_t *Context_SoftProofing = L"Soft Proofing Preview";
@@ -1307,6 +1309,7 @@ struct CN {
   static constexpr const wchar_t *Settings_Tooltip_HdrPeakNitsOverride = L"设为 0 表示通过系统自动检测亮度.";
   static constexpr const wchar_t *Settings_Option_HdrPerceptual = L"感知";
   static constexpr const wchar_t *Settings_Option_HdrColorimetric = L"色度";
+  static constexpr const wchar_t *Settings_Option_HdrSpline = L"Spline (libplacebo)";
   static constexpr const wchar_t *Settings_Label_CmsFallback = L"无配置图片的默认回退";
   static constexpr const wchar_t *Settings_Label_CustomProof = L"自定义软打样配置 (.icc)";
   static constexpr const wchar_t *Context_SoftProofing = L"软打样预览";
@@ -1966,6 +1969,7 @@ struct TW {
   static constexpr const wchar_t *Settings_Tooltip_HdrPeakNitsOverride = L"設為 0 表示通過系統自動檢測亮度.";
   static constexpr const wchar_t *Settings_Option_HdrPerceptual = L"感知";
   static constexpr const wchar_t *Settings_Option_HdrColorimetric = L"色度";
+  static constexpr const wchar_t *Settings_Option_HdrSpline = L"Spline (libplacebo)";
   static constexpr const wchar_t *Settings_Label_CmsFallback = L"無配置圖片的預設回退";
   static constexpr const wchar_t *Settings_Label_CustomProof = L"自訂軟打樣配置 (.icc)";
   static constexpr const wchar_t *Context_SoftProofing = L"軟打樣預覽";
@@ -2540,6 +2544,7 @@ struct JA {
   static constexpr const wchar_t *Settings_Tooltip_HdrPeakNitsOverride = L"システム検出輝度を使用する場合は0に設定します。";
   static constexpr const wchar_t *Settings_Option_HdrPerceptual = L"知覚的";
   static constexpr const wchar_t *Settings_Option_HdrColorimetric = L"測色";
+  static constexpr const wchar_t *Settings_Option_HdrSpline = L"Spline (libplacebo)";
   static constexpr const wchar_t *Settings_Label_CmsFallback = L"プロファイルなし画像のフォールバック";
   static constexpr const wchar_t *Settings_Label_CustomProof = L"ソフトプルーフプロファイル (.icc)";
   static constexpr const wchar_t *Context_SoftProofing = L"ソフトプルーフプレビュー";
@@ -3196,6 +3201,7 @@ struct RU {
   static constexpr const wchar_t *Settings_Tooltip_HdrPeakNitsOverride = L"Установите 0 для системной яркости.";
   static constexpr const wchar_t *Settings_Option_HdrPerceptual = L"Перцептивная";
   static constexpr const wchar_t *Settings_Option_HdrColorimetric = L"Колориметрическая";
+  static constexpr const wchar_t *Settings_Option_HdrSpline = L"Spline (libplacebo)";
   static constexpr const wchar_t *Settings_Label_CmsFallback = L"Запасной профиль без тегов";
   static constexpr const wchar_t *Settings_Label_CustomProof = L"Профиль цветопробы (.icc)";
   static constexpr const wchar_t *Context_SoftProofing = L"Предпросмотр цветопробы";
@@ -3790,6 +3796,7 @@ struct DE {
   static constexpr const wchar_t *Settings_Tooltip_HdrPeakNitsOverride = L"Auf 0 setzen, um erkannte Helligkeit zu verwenden.";
   static constexpr const wchar_t *Settings_Option_HdrPerceptual = L"Perzeptiv";
   static constexpr const wchar_t *Settings_Option_HdrColorimetric = L"Farbmetrisch";
+  static constexpr const wchar_t *Settings_Option_HdrSpline = L"Spline (libplacebo)";
   static constexpr const wchar_t *Settings_Label_CmsFallback = L"Fallback für Bilder ohne Tags";
   static constexpr const wchar_t *Settings_Label_CustomProof = L"Softproof-Profil (.icc)";
   static constexpr const wchar_t *Context_SoftProofing = L"Softproof-Vorschau";
@@ -4397,6 +4404,7 @@ struct ES {
   static constexpr const wchar_t *Settings_Tooltip_HdrPeakNitsOverride = L"Ajustar en 0 para usar el brillo detectado por el sistema.";
   static constexpr const wchar_t *Settings_Option_HdrPerceptual = L"Perceptual";
   static constexpr const wchar_t *Settings_Option_HdrColorimetric = L"Colorimétrico";
+  static constexpr const wchar_t *Settings_Option_HdrSpline = L"Spline (libplacebo)";
   static constexpr const wchar_t *Settings_Label_CmsFallback = L"Perfil alternativo sin etiquetas";
   static constexpr const wchar_t *Settings_Label_CustomProof = L"Perfil de prueba en pantalla (.icc)";
   static constexpr const wchar_t *Context_SoftProofing = L"Vista previa de prueba en pantalla";
@@ -4925,6 +4933,7 @@ template <typename T> void ApplyT() {
   Settings_Tooltip_HdrPeakNitsOverride = T::Settings_Tooltip_HdrPeakNitsOverride;
   Settings_Option_HdrPerceptual = T::Settings_Option_HdrPerceptual;
   Settings_Option_HdrColorimetric = T::Settings_Option_HdrColorimetric;
+  Settings_Option_HdrSpline = T::Settings_Option_HdrSpline;
   Settings_Label_CmsFallback = T::Settings_Label_CmsFallback;
   Settings_Label_CustomProof = T::Settings_Label_CustomProof;
   Context_SoftProofing = T::Context_SoftProofing;
@@ -5488,6 +5497,7 @@ struct FR {
   static constexpr const wchar_t *Settings_Tooltip_HdrPeakNitsOverride = L"Set to 0 to use system detected brightness.";
   static constexpr const wchar_t *Settings_Option_HdrPerceptual = L"Perceptual";
   static constexpr const wchar_t *Settings_Option_HdrColorimetric = L"Colorimetric";
+  static constexpr const wchar_t *Settings_Option_HdrSpline = L"Spline (libplacebo)";
   static constexpr const wchar_t *Settings_Label_CmsFallback = L"Untagged Image Fallback";
   static constexpr const wchar_t *Settings_Label_CustomProof = L"Soft Proof Profile (.icc)";
   static constexpr const wchar_t *Context_SoftProofing = L"Soft Proofing Preview";

--- a/QuickView/AppStrings.h
+++ b/QuickView/AppStrings.h
@@ -345,6 +345,7 @@ namespace AppStrings {
     extern const wchar_t* Settings_Tooltip_HdrPeakNitsOverride;
     extern const wchar_t* Settings_Option_HdrPerceptual;
     extern const wchar_t* Settings_Option_HdrColorimetric;
+    extern const wchar_t* Settings_Option_HdrSpline;
     extern const wchar_t* Settings_Label_CustomProof;
     extern const wchar_t* Settings_Label_CmsIntent;
     extern const wchar_t* Settings_Label_GamutWarning;

--- a/QuickView/ComputeEngine.cpp
+++ b/QuickView/ComputeEngine.cpp
@@ -54,10 +54,53 @@ cbuffer ToneMapParams : register(b0)
     float PaperWhiteScRgb;
     float Exposure;
     uint ToneMappingMode;
-    float _pad0;
-    float _pad1;
-    float _pad2;
+    float src_pivot;
+    float dst_pivot;
+    float Qa;
+    float Qb;
+    float Qc;
+    float Pa;
+    float Pb;
 };
+
+float PQ_OETF(float x)
+{
+    x = max(0.0, x * 10000.0 / 10000.0);
+    float m1 = 0.1593017578125;
+    float m2 = 78.84375;
+    float c1 = 0.8359375;
+    float c2 = 18.8515625;
+    float c3 = 18.6875;
+    x = pow(x, m1);
+    return pow((c1 + c2 * x) / (1.0 + c3 * x), m2);
+}
+
+float PQ_EOTF(float x)
+{
+    float m1 = 0.1593017578125;
+    float m2 = 78.84375;
+    float c1 = 0.8359375;
+    float c2 = 18.8515625;
+    float c3 = 18.6875;
+    x = pow(x, 1.0 / m2);
+    x = max(x - c1, 0.0) / (c2 - c3 * x);
+    return pow(x, 1.0 / m1);
+}
+
+float3 ToneMapSpline(float3 color)
+{
+    float L = max(color.r, max(color.g, color.b));
+    if (L <= 0.0) return (float3)0;
+
+    float L_pq = PQ_OETF(L * 80.0 / 10000.0);
+    L_pq -= src_pivot;
+    float mapped_L_pq = L_pq > 0.0 ? ((Qa * L_pq + Qb) * L_pq + Qc) * L_pq : (Pa * L_pq + Pb) * L_pq;
+    mapped_L_pq += dst_pivot;
+
+    float mapped_L = PQ_EOTF(mapped_L_pq) * 10000.0 / 80.0;
+    float scale = mapped_L / L;
+    return color * scale;
+}
 
 float3 LinearToSrgb(float3 value)
 {
@@ -113,6 +156,10 @@ void CSToneMap(uint3 id : SV_DispatchThreadID)
     if (ToneMappingMode == 1) {
         // Colorimetric Mode: Hard clip at display peak (normalized to [0,1])
         float3 mapped = clamp(color.rgb / displayPeak, 0.0, 1.0);
+        float3 encoded = LinearToSrgb(mapped) * color.a;
+        DstTex[id.xy] = float4(encoded.r, encoded.g, encoded.b, color.a);
+    } else if (ToneMappingMode == 2) {
+        float3 mapped = ToneMapSpline(color.rgb);
         float3 encoded = LinearToSrgb(mapped) * color.a;
         DstTex[id.xy] = float4(encoded.r, encoded.g, encoded.b, color.a);
     } else {
@@ -777,25 +824,7 @@ HRESULT ComputeEngine::ToneMapHdrToSdr(const uint8_t* srcPixels, int width, int 
     hr = m_d3dContext->Map(m_toneMapConstantBuffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
     if (FAILED(hr)) return hr;
 
-    struct CBParams {
-        float contentPeakScRgb;
-        float displayPeakScRgb;
-        float paperWhiteScRgb;
-        float exposure;
-        uint32_t toneMappingMode;
-        float _pad0;
-        float _pad1;
-        float _pad2;
-    };
-    CBParams params = {
-        settings.contentPeakScRgb,
-        settings.displayPeakScRgb,
-        settings.paperWhiteScRgb,
-        settings.exposure,
-        (uint32_t)settings.toneMappingMode,
-        0.0f, 0.0f, 0.0f
-    };
-    memcpy(mapped.pData, &params, sizeof(params));
+    memcpy(mapped.pData, &settings, sizeof(ToneMapSettings));
     m_d3dContext->Unmap(m_toneMapConstantBuffer.Get(), 0);
 
     m_d3dContext->CSSetShader(m_csToneMapHdrToSdr.Get(), nullptr, 0);
@@ -866,25 +895,7 @@ HRESULT ComputeEngine::ToneMapHdrToHdr(const uint8_t* srcPixels, int width, int 
     hr = m_d3dContext->Map(m_toneMapConstantBuffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
     if (FAILED(hr)) return hr;
 
-    struct CBParams {
-        float contentPeakScRgb;
-        float displayPeakScRgb;
-        float paperWhiteScRgb;
-        float exposure;
-        uint32_t toneMappingMode;
-        float _pad0;
-        float _pad1;
-        float _pad2;
-    };
-    CBParams params = {
-        settings.contentPeakScRgb,
-        settings.displayPeakScRgb,
-        settings.paperWhiteScRgb,
-        settings.exposure,
-        (uint32_t)settings.toneMappingMode,
-        0.0f, 0.0f, 0.0f
-    };
-    memcpy(mapped.pData, &params, sizeof(params));
+    memcpy(mapped.pData, &settings, sizeof(ToneMapSettings));
     m_d3dContext->Unmap(m_toneMapConstantBuffer.Get(), 0);
 
     m_d3dContext->CSSetShader(m_csToneMapHdrToHdr.Get(), nullptr, 0);

--- a/QuickView/ComputeEngine.h
+++ b/QuickView/ComputeEngine.h
@@ -16,7 +16,15 @@ struct alignas(16) ToneMapSettings {
     float paperWhiteScRgb = 1.0f;
     float exposure = 1.0f;
     int toneMappingMode = 0;
-    float _pad0[3] = {};
+
+    // Spline parameters
+    float src_pivot = 0.0f;
+    float dst_pivot = 0.0f;
+    float Qa = 0.0f;
+    float Qb = 0.0f;
+    float Qc = 0.0f;
+    float Pa = 0.0f;
+    float Pb = 0.0f;
 };
 static_assert(sizeof(ToneMapSettings) % 16 == 0, "CB size must be multiple of 16 bytes");
 

--- a/QuickView/RenderEngine.cpp
+++ b/QuickView/RenderEngine.cpp
@@ -782,6 +782,77 @@ BuildToneMapSettings(const QuickView::RawImageFrame &frame,
   settings.paperWhiteScRgb = paperWhiteScRgb;
   settings.toneMappingMode = g_config.HdrToneMappingMode;
 
+  if (settings.toneMappingMode == 2) { // Spline (libplacebo)
+      const float knee_adaptation = 0.4f;
+      const float knee_minimum = 0.1f;
+      const float knee_maximum = 0.8f;
+      const float knee_default = 0.4f;
+      const float slope_tuning = 1.5f;
+      const float slope_offset = 0.2f;
+      const float spline_contrast = 0.5f;
+
+      // libplacebo linear_to_pq inline
+      auto pq_oetf = [](float x) -> float {
+          x = std::max(0.0f, x * 10000.0f / 10000.0f); // libplacebo normalizes to 10k nits
+          const float m1 = 0.1593017578125f;
+          const float m2 = 78.84375f;
+          const float c1 = 0.8359375f;
+          const float c2 = 18.8515625f;
+          const float c3 = 18.6875f;
+          x = std::pow(x, m1);
+          return std::pow((c1 + c2 * x) / (1.0f + c3 * x), m2);
+      };
+
+      float src_min = pq_oetf(0.0f);
+      float src_max = pq_oetf(settings.contentPeakScRgb * 80.0f / 10000.0f);
+      float src_avg = pq_oetf(contentAverageScRgb * 80.0f / 10000.0f);
+      float dst_min = pq_oetf(0.0f);
+      float dst_max = pq_oetf(settings.displayPeakScRgb * 80.0f / 10000.0f);
+
+      float src_knee_min = src_min + (src_max - src_min) * knee_minimum;
+      float src_knee_max = src_min + (src_max - src_min) * knee_maximum;
+      float dst_knee_min = dst_min + (dst_max - dst_min) * knee_minimum;
+      float dst_knee_max = dst_min + (dst_max - dst_min) * knee_maximum;
+
+      float def_knee_val = src_min + (src_max - src_min) * knee_default;
+      float src_knee = (src_avg > 0.0f) ? src_avg : def_knee_val;
+      src_knee = std::clamp(src_knee, src_knee_min, src_knee_max);
+
+      float target = (src_knee - src_min) / std::max(1e-6f, src_max - src_min);
+      float adapted = dst_min + (dst_max - dst_min) * target;
+
+      auto smoothstep = [](float edge0, float edge1, float x) -> float {
+          float t = std::clamp((x - edge0) / (edge1 - edge0), 0.0f, 1.0f);
+          return t * t * (3.0f - 2.0f * t);
+      };
+
+      float tuning = 1.0f - smoothstep(knee_maximum, knee_default, target) * smoothstep(knee_minimum, knee_default, target);
+      float adaptation = knee_adaptation + (1.0f - knee_adaptation) * tuning;
+      float dst_knee = src_knee + (adapted - src_knee) * adaptation;
+      dst_knee = std::clamp(dst_knee, dst_knee_min, dst_knee_max);
+
+      settings.src_pivot = src_knee;
+      settings.dst_pivot = dst_knee;
+
+      float slope = (dst_knee - dst_min) / std::max(1e-6f, src_knee - src_min);
+      float ratio = (settings.contentPeakScRgb / std::max(1e-6f, settings.displayPeakScRgb)) - 1.0f;
+      ratio = std::clamp(slope_tuning * ratio, slope_offset, 1.0f + slope_offset);
+      slope = std::pow(slope, (1.0f - spline_contrast) * ratio);
+
+      float in_min = src_min - src_knee;
+      float in_max = src_max - src_knee;
+      float out_min = dst_min - dst_knee;
+      float out_max = dst_max - dst_knee;
+
+      settings.Pa = (out_min - slope * in_min) / std::max(1e-6f, in_min * in_min);
+      settings.Pb = slope;
+
+      float t = 2.0f * in_max * in_max;
+      settings.Qa = (slope * in_max - out_max) / std::max(1e-6f, in_max * t);
+      settings.Qb = -3.0f * (slope * in_max - out_max) / std::max(1e-6f, t);
+      settings.Qc = slope;
+  }
+
   const float headroom = settings.displayPeakScRgb / settings.paperWhiteScRgb;
   settings.exposure = 1.0f;
   if (frame.hdrMetadata.hasGainMap) {
@@ -1945,6 +2016,42 @@ CRenderEngine::UploadRawFrameToGPU(const QuickView::RawImageFrame &frame,
                       float premulR, premulG, premulB;
                       if (toneMapSettings.toneMappingMode == 1) { // Colorimetric
                           premulR = std::min(1.0f, r) * a; premulG = std::min(1.0f, g) * a; premulB = std::min(1.0f, b) * a;
+                      } else if (toneMapSettings.toneMappingMode == 2) { // Spline
+                          auto pq_oetf = [](float x) -> float {
+                              x = std::max(0.0f, x * 10000.0f / 10000.0f);
+                              const float m1 = 0.1593017578125f;
+                              const float m2 = 78.84375f;
+                              const float c1 = 0.8359375f;
+                              const float c2 = 18.8515625f;
+                              const float c3 = 18.6875f;
+                              x = std::pow(x, m1);
+                              return std::pow((c1 + c2 * x) / (1.0f + c3 * x), m2);
+                          };
+                          auto pq_eotf = [](float x) -> float {
+                              const float m1 = 0.1593017578125f;
+                              const float m2 = 78.84375f;
+                              const float c1 = 0.8359375f;
+                              const float c2 = 18.8515625f;
+                              const float c3 = 18.6875f;
+                              x = std::pow(x, 1.0f / m2);
+                              x = std::max(x - c1, 0.0f) / (c2 - c3 * x);
+                              return std::pow(x, 1.0f / m1);
+                          };
+
+                          float l = std::max(r, std::max(g, b));
+                          if (l <= 0.0f) {
+                              premulR = premulG = premulB = 0.0f;
+                          } else {
+                              float lpq = pq_oetf(l * 80.0f / 10000.0f);
+                              lpq -= toneMapSettings.src_pivot;
+                              float mapped_lpq = lpq > 0.0f ? ((toneMapSettings.Qa * lpq + toneMapSettings.Qb) * lpq + toneMapSettings.Qc) * lpq : (toneMapSettings.Pa * lpq + toneMapSettings.Pb) * lpq;
+                              mapped_lpq += toneMapSettings.dst_pivot;
+                              float mapped_l = pq_eotf(mapped_lpq) * 10000.0f / 80.0f;
+                              float scale = mapped_l / l;
+                              premulR = r * scale * a;
+                              premulG = g * scale * a;
+                              premulB = b * scale * a;
+                          }
                       } else { // Perceptual: Reinhard Extended (matches GPU shader)
                           float mapR, mapG, mapB;
                           ReinhardExtendedRGB(r, g, b, Lwhite, mapR, mapG, mapB);

--- a/QuickView/RenderEngine.cpp
+++ b/QuickView/RenderEngine.cpp
@@ -835,7 +835,7 @@ BuildToneMapSettings(const QuickView::RawImageFrame &frame,
       settings.dst_pivot = dst_knee;
 
       float slope = (dst_knee - dst_min) / std::max(1e-6f, src_knee - src_min);
-      float ratio = (settings.contentPeakScRgb / std::max(1e-6f, settings.displayPeakScRgb)) - 1.0f;
+      float ratio = (settings.contentPeakScRgb * 80.0f / 10000.0f) / std::max(1e-6f, settings.displayPeakScRgb * 80.0f / 10000.0f) - 1.0f;
       ratio = std::clamp(slope_tuning * ratio, slope_offset, 1.0f + slope_offset);
       slope = std::pow(slope, (1.0f - spline_contrast) * ratio);
 

--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -1787,7 +1787,7 @@ void SettingsOverlay::BuildMenu() {
     tabImage.items.push_back(itemAdvColor);
 
     SettingsItem itemHdrToneMapping = { AppStrings::Settings_Label_HdrToneMapping, OptionType::ComboBox, nullptr, nullptr, &g_config.HdrToneMappingMode, nullptr, 0, 0,
-        { AppStrings::Settings_Option_HdrPerceptual, AppStrings::Settings_Option_HdrColorimetric } };
+        { AppStrings::Settings_Option_HdrPerceptual, AppStrings::Settings_Option_HdrColorimetric, AppStrings::Settings_Option_HdrSpline } };
     itemHdrToneMapping.tooltipText = AppStrings::Settings_Tooltip_HdrToneMapping;
     itemHdrToneMapping.onChange = []() {
         SaveConfig();


### PR DESCRIPTION
Implemented libplacebo's spline tone mapping for HDR within the QuickView engine. Parameters are calculated CPU-side via inline PQ functions and sent to DirectCompute shaders for execution (or mapped directly in the CPU fallback). Supported in English, Chinese, Japanese, Russian, Spanish, and German locales.

---
*PR created automatically by Jules for task [15511813699964517173](https://jules.google.com/task/15511813699964517173) started by @justnullname*