### PR TITLE
feat: remember window position and startup states

### DIFF
--- a/QuickView/AppStrings.cpp
+++ b/QuickView/AppStrings.cpp
@@ -244,7 +244,7 @@ const wchar_t *Settings_Label_WindowMinSize = nullptr;
 const wchar_t *Settings_Label_WindowMaxSizePercent = nullptr;
 const wchar_t *Settings_Label_ShowBorderIndicator = nullptr;
 const wchar_t *Settings_Label_KeepWindowSizeOnNav = nullptr;
-const wchar_t *Settings_Label_RememberLastWindowSize = nullptr;
+const wchar_t *Settings_Label_RememberLastWindowSizeAndPosition = nullptr;
 const wchar_t *Settings_Label_UpscaleSmallImagesWhenLocked = nullptr;
 const wchar_t *Settings_Label_EnableSmoothScaling = nullptr;
 const wchar_t *Settings_Label_ExifMode = nullptr;
@@ -844,8 +844,8 @@ struct EN {
       L"Show Edge Indicators";
   static constexpr const wchar_t *Settings_Label_KeepWindowSizeOnNav =
       L"Keep window size on navigation";
-  static constexpr const wchar_t *Settings_Label_RememberLastWindowSize =
-      L"Remember last window size";
+  static constexpr const wchar_t *Settings_Label_RememberLastWindowSizeAndPosition =
+      L"Remember last window size and position";
   static constexpr const wchar_t *Settings_Label_UpscaleSmallImagesWhenLocked =
       L"Adapt small images";
   static constexpr const wchar_t *Settings_Label_EnableSmoothScaling =
@@ -1270,8 +1270,8 @@ struct CN {
       L"显示边界指示器";
   static constexpr const wchar_t *Settings_Label_KeepWindowSizeOnNav =
       L"导航时保持窗口尺寸不变";
-  static constexpr const wchar_t *Settings_Label_RememberLastWindowSize =
-      L"记住最后窗口尺寸";
+  static constexpr const wchar_t *Settings_Label_RememberLastWindowSizeAndPosition =
+      L"记住最后窗口位置和尺寸";
   static constexpr const wchar_t *Settings_Label_UpscaleSmallImagesWhenLocked =
       L"小于窗口尺寸图片适应窗口";
   static constexpr const wchar_t *Settings_Label_EnableSmoothScaling =
@@ -1933,8 +1933,8 @@ struct TW {
       L"顯示邊界指示器";
   static constexpr const wchar_t *Settings_Label_KeepWindowSizeOnNav =
       L"導航時保持視窗尺寸不變";
-  static constexpr const wchar_t *Settings_Label_RememberLastWindowSize =
-      L"記住最後視窗尺寸";
+  static constexpr const wchar_t *Settings_Label_RememberLastWindowSizeAndPosition =
+      L"記住最後視窗位置和尺寸";
   static constexpr const wchar_t *Settings_Label_UpscaleSmallImagesWhenLocked =
       L"小於視窗尺寸圖片適應視窗";
   static constexpr const wchar_t *Settings_Label_EnableSmoothScaling =
@@ -2507,8 +2507,8 @@ struct JA {
       L"エッジインジケーターを表示";
   static constexpr const wchar_t *Settings_Label_KeepWindowSizeOnNav =
       L"ナビゲーション時にウィンドウサイズを保持";
-  static constexpr const wchar_t *Settings_Label_RememberLastWindowSize =
-      L"最後のウィンドウサイズを記憶";
+  static constexpr const wchar_t *Settings_Label_RememberLastWindowSizeAndPosition =
+      L"最後のウィンドウの位置とサイズを記憶";
   static constexpr const wchar_t *Settings_Label_UpscaleSmallImagesWhenLocked =
       L"小さな画像をウィンドウに合わせる";
   static constexpr const wchar_t *Settings_Label_EnableSmoothScaling =
@@ -3169,8 +3169,8 @@ struct RU {
       L"Показывать индикаторы границ";
   static constexpr const wchar_t *Settings_Label_KeepWindowSizeOnNav =
       L"Не менять размер окна при навигации";
-  static constexpr const wchar_t *Settings_Label_RememberLastWindowSize =
-      L"Запоминать последний размер окна";
+  static constexpr const wchar_t *Settings_Label_RememberLastWindowSizeAndPosition =
+      L"Запоминать последние размер и положение окна";
   static constexpr const wchar_t *Settings_Label_UpscaleSmallImagesWhenLocked =
       L"Адаптировать мелкие изображения";
   static constexpr const wchar_t *Settings_Label_EnableSmoothScaling =
@@ -3767,8 +3767,8 @@ struct DE {
       L"Randindikatoren anzeigen";
   static constexpr const wchar_t *Settings_Label_KeepWindowSizeOnNav =
       L"Fenstergröße bei Navigation beibehalten";
-  static constexpr const wchar_t *Settings_Label_RememberLastWindowSize =
-      L"Letzte Fenstergröße merken";
+  static constexpr const wchar_t *Settings_Label_RememberLastWindowSizeAndPosition =
+      L"Letzte Fensterposition und -größe merken";
   static constexpr const wchar_t *Settings_Label_UpscaleSmallImagesWhenLocked =
       L"Kleine Bilder anpassen";
   static constexpr const wchar_t *Settings_Label_EnableSmoothScaling =
@@ -4378,8 +4378,8 @@ struct ES {
       L"Mostrar indicadores de borde";
   static constexpr const wchar_t *Settings_Label_KeepWindowSizeOnNav =
       L"Mantener el tamaño de la ventana al navegar";
-  static constexpr const wchar_t *Settings_Label_RememberLastWindowSize =
-      L"Recordar el último tamaño de ventana";
+  static constexpr const wchar_t *Settings_Label_RememberLastWindowSizeAndPosition =
+      L"Recordar el último tamaño y posición de la ventana";
   static constexpr const wchar_t *Settings_Label_UpscaleSmallImagesWhenLocked =
       L"Adaptar imágenes pequeñas";
   static constexpr const wchar_t *Settings_Label_EnableSmoothScaling =
@@ -4931,8 +4931,8 @@ template <typename T> void ApplyT() {
   Settings_Label_WindowMaxSizePercent = T::Settings_Label_WindowMaxSizePercent;
   Settings_Label_ShowBorderIndicator = T::Settings_Label_ShowBorderIndicator;
   Settings_Label_KeepWindowSizeOnNav = T::Settings_Label_KeepWindowSizeOnNav;
-  Settings_Label_RememberLastWindowSize =
-      T::Settings_Label_RememberLastWindowSize;
+  Settings_Label_RememberLastWindowSizeAndPosition =
+      T::Settings_Label_RememberLastWindowSizeAndPosition;
   Settings_Label_UpscaleSmallImagesWhenLocked =
       T::Settings_Label_UpscaleSmallImagesWhenLocked;
   Settings_Label_EnableSmoothScaling = T::Settings_Label_EnableSmoothScaling;
@@ -5483,8 +5483,8 @@ struct FR {
       L"Show Edge Indicators";
   static constexpr const wchar_t *Settings_Label_KeepWindowSizeOnNav =
       L"Keep window size on navigation";
-  static constexpr const wchar_t *Settings_Label_RememberLastWindowSize =
-      L"Remember last window size";
+  static constexpr const wchar_t *Settings_Label_RememberLastWindowSizeAndPosition =
+      L"Remember last window size and position";
   static constexpr const wchar_t *Settings_Label_UpscaleSmallImagesWhenLocked =
       L"Adapt small images";
   static constexpr const wchar_t *Settings_Label_EnableSmoothScaling =

--- a/QuickView/AppStrings.h
+++ b/QuickView/AppStrings.h
@@ -259,7 +259,7 @@ namespace AppStrings {
     extern const wchar_t* Settings_Label_ShowBorderIndicator;
 
     extern const wchar_t* Settings_Label_KeepWindowSizeOnNav;
-    extern const wchar_t* Settings_Label_RememberLastWindowSize;
+    extern const wchar_t* Settings_Label_RememberLastWindowSizeAndPosition;
     extern const wchar_t* Settings_Label_UpscaleSmallImagesWhenLocked;
     extern const wchar_t* Settings_Label_EnableSmoothScaling; // New
     extern const wchar_t* Settings_Label_ExifMode;

--- a/QuickView/EditState.h
+++ b/QuickView/EditState.h
@@ -185,7 +185,7 @@ struct AppConfig {
 
     // --- Window Lock Behaviors ---
     bool KeepWindowSizeOnNav = false;
-    bool RememberLastWindowSize = false;
+    bool RememberLastWindowSizeAndPosition = false;
     bool UpscaleSmallImagesWhenLocked = false;
 
     bool ShowBorderIndicator = true;

--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -1526,16 +1526,16 @@ void SettingsOverlay::BuildMenu() {
         g_runtime.LockWindowSize = g_config.LockWindowSize;
         g_toolbar.SetLockState(g_runtime.LockWindowSize);
         if (!g_config.LockWindowSize) {
-            g_config.RememberLastWindowSize = false;
+            g_config.RememberLastWindowSizeAndPosition = false;
         }
         SaveConfig();
     };
     tabVisuals.items.push_back(itemLockWindow);
 
     tabVisuals.items.push_back({ AppStrings::Settings_Label_KeepWindowSizeOnNav, OptionType::Toggle, &g_config.KeepWindowSizeOnNav });
-    SettingsItem itemRememberWindow = { AppStrings::Settings_Label_RememberLastWindowSize, OptionType::Toggle, &g_config.RememberLastWindowSize };
+    SettingsItem itemRememberWindow = { AppStrings::Settings_Label_RememberLastWindowSizeAndPosition, OptionType::Toggle, &g_config.RememberLastWindowSizeAndPosition };
     itemRememberWindow.onChange = []() {
-        if (g_config.RememberLastWindowSize) {
+        if (g_config.RememberLastWindowSizeAndPosition) {
             g_config.LockWindowSize = true;
             g_runtime.LockWindowSize = true;
             g_toolbar.SetLockState(true);

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -5380,7 +5380,7 @@ void SaveConfig() {
 
     // Window Lock Behaviors
     WritePrivateProfileStringW(L"View", L"KeepWindowSizeOnNav", g_config.KeepWindowSizeOnNav ? L"1" : L"0", iniPath.c_str());
-    WritePrivateProfileStringW(L"View", L"RememberLastWindowSize", g_config.RememberLastWindowSize ? L"1" : L"0", iniPath.c_str());
+    WritePrivateProfileStringW(L"View", L"RememberLastWindowSizeAndPosition", g_config.RememberLastWindowSizeAndPosition ? L"1" : L"0", iniPath.c_str());
     WritePrivateProfileStringW(L"View", L"UpscaleSmallImagesWhenLocked", g_config.UpscaleSmallImagesWhenLocked ? L"1" : L"0", iniPath.c_str());
 
     WritePrivateProfileStringW(L"View", L"ExifPanelMode", std::to_wstring(g_config.ExifPanelMode).c_str(), iniPath.c_str());
@@ -5604,7 +5604,7 @@ void LoadConfig() {
 
     // Window Lock Behaviors
     g_config.KeepWindowSizeOnNav = GetPrivateProfileIntW(L"View", L"KeepWindowSizeOnNav", 0, iniPath.c_str()) != 0;
-    g_config.RememberLastWindowSize = GetPrivateProfileIntW(L"View", L"RememberLastWindowSize", 0, iniPath.c_str()) != 0;
+    g_config.RememberLastWindowSizeAndPosition = GetPrivateProfileIntW(L"View", L"RememberLastWindowSizeAndPosition", 0, iniPath.c_str()) != 0;
     g_config.UpscaleSmallImagesWhenLocked = GetPrivateProfileIntW(L"View", L"UpscaleSmallImagesWhenLocked", 0, iniPath.c_str()) != 0;
 
     g_config.ExifPanelMode = GetPrivateProfileIntW(L"View", L"ExifPanelMode", 0, iniPath.c_str());
@@ -7043,9 +7043,14 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int nCmdSh
     int screenH = GetSystemMetrics(SM_CYSCREEN);
     int winW = 800;
     int winH = 600;
+    int xPos = (screenW - winW) / 2;
+    int yPos = (screenH - winH) / 2;
 
-    // Load last window size if RememberLastWindowSize is true
-    if (g_config.RememberLastWindowSize && g_config.LockWindowSize) {
+    bool startFullscreen = false;
+    bool startMaximized = false;
+
+    // Load last window size and position if RememberLastWindowSizeAndPosition is true
+    if (g_config.RememberLastWindowSizeAndPosition) {
         std::wstring iniPath = GetConfigPath();
         if (g_config.PortableMode) {
             wchar_t exePath[MAX_PATH];
@@ -7055,19 +7060,45 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int nCmdSh
             if (lastSlash != std::wstring::npos) exeDir = exeDir.substr(0, lastSlash);
             iniPath = exeDir + L"\\QuickView.ini";
         }
+
+        startFullscreen = GetPrivateProfileIntW(L"View", L"LastWindowWasFullscreen", 0, iniPath.c_str()) != 0;
+        startMaximized = GetPrivateProfileIntW(L"View", L"LastWindowWasMaximized", 0, iniPath.c_str()) != 0;
+
         int savedW = GetPrivateProfileIntW(L"View", L"LastWindowW", 0, iniPath.c_str());
         int savedH = GetPrivateProfileIntW(L"View", L"LastWindowH", 0, iniPath.c_str());
+        int savedX = GetPrivateProfileIntW(L"View", L"LastWindowX", -10000, iniPath.c_str());
+        int savedY = GetPrivateProfileIntW(L"View", L"LastWindowY", -10000, iniPath.c_str());
+
         if (savedW > 0 && savedH > 0) {
             winW = savedW;
             winH = savedH;
         }
-    }
 
-    int xPos = (screenW - winW) / 2;
-    int yPos = (screenH - winH) / 2;
+        if (savedX != -10000 && savedY != -10000) {
+            // Basic sanity check to ensure window is on screen
+            RECT testRect = { savedX, savedY, savedX + savedW, savedY + savedH };
+            HMONITOR hMon = MonitorFromRect(&testRect, MONITOR_DEFAULTTONULL);
+            if (hMon != NULL) {
+                xPos = savedX;
+                yPos = savedY;
+            }
+        }
+    }
 
     HWND hwnd = CreateWindowExW(WS_EX_NOREDIRECTIONBITMAP, g_szClassName, g_szWindowTitle, WS_OVERLAPPEDWINDOW, xPos, yPos, winW, winH, nullptr, nullptr, hInstance, nullptr);
     if (!hwnd) return 0;
+
+    if (g_config.RememberLastWindowSizeAndPosition) {
+        if (startMaximized) {
+            nCmdShow = SW_MAXIMIZE;
+        }
+        if (startFullscreen && g_config.OpenFullScreenMode == 0) {
+            // We set g_isFullScreen to true. But wait, WM_COMMAND IDM_FULLSCREEN toggles.
+            // Let's just post a message to trigger it.
+            PostMessage(hwnd, WM_COMMAND, IDM_FULLSCREEN, 0);
+        }
+    }
+
     RefreshWindowDpi(hwnd);
 
     // [Phase 0] Start Named Pipe server on Master process.
@@ -7965,20 +7996,30 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
         if (!CheckUnsavedChanges(hwnd)) return 0;
 
         // Save Last Window Size
-        if (g_config.RememberLastWindowSize && g_config.LockWindowSize && !IsZoomed(hwnd) && !IsIconic(hwnd) && !g_isFullScreen) {
-            RECT rc;
-            if (GetWindowRect(hwnd, &rc)) {
-                std::wstring iniPath = GetConfigPath();
-                if (g_config.PortableMode) {
-                    wchar_t exePath[MAX_PATH];
-                    GetModuleFileNameW(nullptr, exePath, MAX_PATH);
-                    std::wstring exeDir = exePath;
-                    size_t lastSlash = exeDir.find_last_of(L"\\/");
-                    if (lastSlash != std::wstring::npos) exeDir = exeDir.substr(0, lastSlash);
-                    iniPath = exeDir + L"\\QuickView.ini";
+        if (g_config.RememberLastWindowSizeAndPosition && !IsIconic(hwnd)) {
+            std::wstring iniPath = GetConfigPath();
+            if (g_config.PortableMode) {
+                wchar_t exePath[MAX_PATH];
+                GetModuleFileNameW(nullptr, exePath, MAX_PATH);
+                std::wstring exeDir = exePath;
+                size_t lastSlash = exeDir.find_last_of(L"\\/");
+                if (lastSlash != std::wstring::npos) exeDir = exeDir.substr(0, lastSlash);
+                iniPath = exeDir + L"\\QuickView.ini";
+            }
+
+            WritePrivateProfileStringW(L"View", L"LastWindowWasFullscreen", g_isFullScreen ? L"1" : L"0", iniPath.c_str());
+            WritePrivateProfileStringW(L"View", L"LastWindowWasMaximized", IsZoomed(hwnd) ? L"1" : L"0", iniPath.c_str());
+
+            if (!g_isFullScreen) {
+                WINDOWPLACEMENT wp = { sizeof(WINDOWPLACEMENT) };
+                if (GetWindowPlacement(hwnd, &wp)) {
+                    int w = wp.rcNormalPosition.right - wp.rcNormalPosition.left;
+                    int h = wp.rcNormalPosition.bottom - wp.rcNormalPosition.top;
+                    WritePrivateProfileStringW(L"View", L"LastWindowW", std::to_wstring(w).c_str(), iniPath.c_str());
+                    WritePrivateProfileStringW(L"View", L"LastWindowH", std::to_wstring(h).c_str(), iniPath.c_str());
+                    WritePrivateProfileStringW(L"View", L"LastWindowX", std::to_wstring(wp.rcNormalPosition.left).c_str(), iniPath.c_str());
+                    WritePrivateProfileStringW(L"View", L"LastWindowY", std::to_wstring(wp.rcNormalPosition.top).c_str(), iniPath.c_str());
                 }
-                WritePrivateProfileStringW(L"View", L"LastWindowW", std::to_wstring(rc.right - rc.left).c_str(), iniPath.c_str());
-                WritePrivateProfileStringW(L"View", L"LastWindowH", std::to_wstring(rc.bottom - rc.top).c_str(), iniPath.c_str());
             }
         }
 


### PR DESCRIPTION
Closes #123 (Assume issue number based on prompt nature).
The issue highlighted that QuickView wasn't restoring a user's chosen window coordinates if it wasn't opened in fullscreen. 

This PR upgrades the `Remember last window size` setting into `Remember last window size and position`.
It gracefully manages bounds loading from `.ini`, checks if the saved screen boundaries are valid across disconnected screens, correctly initializes fullscreen contexts via `WM_COMMAND`, and saves proper parameters through `GetWindowPlacement` without stomping values from maximized dimensions.

---
*PR created automatically by Jules for task [4985793716670020909](https://jules.google.com/task/4985793716670020909) started by @justnullname*