### PR TITLE
feat: Add Comic Dual Page Mode for archive files

### DIFF
--- a/QuickView/FileNavigator.h
+++ b/QuickView/FileNavigator.h
@@ -349,6 +349,12 @@ public:
     // Status info
     size_t Count() const { return m_files.size(); }
     int Index() const { return m_currentIndex; }
+    void SetIndex(int index) {
+        if (index >= 0 && index < (int)m_files.size()) {
+            m_currentIndex = index;
+            m_hitEnd = false;
+        }
+    }
 
     // Random Access (For Gallery Virtualization)
     const std::wstring& GetFile(int index) const {

--- a/QuickView/Toolbar.cpp
+++ b/QuickView/Toolbar.cpp
@@ -180,9 +180,14 @@ void Toolbar::UpdateLayout(float winW, float winH) {
       if (isAlwaysVisible(btn.id)) return true;
       return false;
     }
-    if (m_overlayMode) {
-      if (isOverlayButton(btn.id) || isAlwaysVisible(btn.id)) return true;
-      return false;
+    if (m_comicMode) {
+      // In comic mode, we hide rotate and flip, and compare toolbars
+      // The toggle button is ToolbarButtonID::CompareToggle, which is NOT in isCompareButton
+      if (btn.id == ToolbarButtonID::RotateL || btn.id == ToolbarButtonID::RotateR || btn.id == ToolbarButtonID::FlipH) return false;
+      if (btn.id == ToolbarButtonID::Exif) return false;
+      if (isCompareButton(btn.id)) return false;
+      if (isAnimButton(btn.id) || isOverlayButton(btn.id)) return false;
+      return true;
     }
 
     if (m_compareMode) {
@@ -274,6 +279,14 @@ void Toolbar::UpdateLayout(float winW, float winH) {
         btn.iconGlyph = g_runtime.LockWindowSize ? Icons::Lock : Icons::Unlock;
     }
 
+    if (btn.id == ToolbarButtonID::CompareToggle) {
+      if (m_comicMode) {
+        btn.iconGlyph = Icons::Layout; // Layout looks like a book/dual-page
+      } else {
+        btn.iconGlyph = Icons::CompareToggle;
+      }
+    }
+
     if (visible) {
       btn.rect = D2D1::RectF(cx, cy, cx + buttonSize, cy + buttonSize);
       cx += buttonSize + gap;
@@ -354,6 +367,9 @@ const wchar_t *GetTooltipText(const ToolbarButton &btn) {
     return btn.isToggled ? AppStrings::Toolbar_Tooltip_Unpin
                          : AppStrings::Toolbar_Tooltip_Pin;
   case ToolbarButtonID::CompareToggle:
+    if (g_navigator.GetArchive() != nullptr) {
+      return btn.isToggled ? L"Single Page Mode" : L"Dual Page Mode";
+    }
     return btn.isToggled ? AppStrings::Toolbar_Tooltip_NormalMode : AppStrings::Toolbar_Tooltip_CompareMode;
   case ToolbarButtonID::CompareOpen:
     return AppStrings::Toolbar_Tooltip_CompareOpen;

--- a/QuickView/Toolbar.h
+++ b/QuickView/Toolbar.h
@@ -89,6 +89,8 @@ public:
     void SetGamutWarningActive(bool active);
     void SetCompareMode(bool enabled);
     bool IsCompareMode() const { return m_compareMode; }
+    void SetComicMode(bool enabled) { m_comicMode = enabled; }
+    bool IsComicMode() const { return m_comicMode; }
     void SetCompareSyncStates(bool syncZoom, bool syncPan);
     void SetCompareInfoState(bool active);
     void SetCompareRawState(bool anyRaw, bool selectedIsRaw, bool isFullDecode);
@@ -138,6 +140,7 @@ private:
     bool m_isPinned = false;
     bool m_windowTooNarrow = false; // [Phase 3] Hide toolbar if window is too narrow
     bool m_compareMode = false;
+    bool m_comicMode = false;
     bool m_animMode = false;
     bool m_animPlaying = true;
     bool m_animDirtyRect = false;

--- a/QuickView/UIRenderer.cpp
+++ b/QuickView/UIRenderer.cpp
@@ -25,6 +25,9 @@ extern SettingsOverlay g_settingsOverlay;
 extern HelpOverlay g_helpOverlay;
 extern ImageEngine* g_pImageEngine; // [v3.1] Accessor (renamed from g_imageEngine)
 
+#include "FileNavigator.h"
+extern FileNavigator g_navigator;
+
 // DrawDialog is still in main.cpp (modal dialog handling)
 extern void DrawDialog(ID2D1DeviceContext* context, const RECT& clientRect);
 
@@ -2606,6 +2609,16 @@ void UIRenderer::DrawCompactInfo(ID2D1DeviceContext* dc) {
         info = frameBuf;
     } else {
         info = g_imagePath.substr(g_imagePath.find_last_of(L"\\/") + 1);
+
+        // Add Comic Page Info if in Archive
+        if (g_navigator.GetArchive() != nullptr) {
+            int currentPage = g_navigator.Index() + 1;
+            size_t totalPages = g_navigator.Count();
+            if (totalPages > 0) {
+                wchar_t sz[64]; swprintf_s(sz, L"   [%d / %zu]", currentPage, totalPages);
+                info += sz;
+            }
+        }
     
         // Add Size
         if (g_currentMetadata.Width > 0) {

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -2290,8 +2290,51 @@ static void EnterCompareMode(HWND hwnd) {
         return;
     }
 
-    CaptureCurrentImageAsCompareLeft();
-    if (!g_compare.left.valid) return;
+    if (g_toolbar.IsComicMode() && g_navigator.Count() > 0) {
+        int currentIndex = g_navigator.Index();
+
+        // Force right to be even
+        int rightIndex = (currentIndex + 1) & ~1;
+        int leftIndex = rightIndex - 1;
+
+        std::wstring leftPath;
+        if (leftIndex >= 0 && leftIndex < (int)g_navigator.Count()) {
+            leftPath = g_navigator.GetFile(leftIndex);
+        }
+
+        std::wstring rightPath;
+        if (rightIndex >= 0 && rightIndex < (int)g_navigator.Count()) {
+            rightPath = g_navigator.GetFile(rightIndex);
+        }
+
+        if (rightPath.empty()) {
+            rightPath = leftPath;
+            leftPath = L"";
+            g_navigator.SetIndex(leftIndex);
+        } else {
+            g_navigator.SetIndex(rightIndex);
+        }
+
+        if (!leftPath.empty()) {
+            LoadImageIntoCompareLeftSlot(hwnd, leftPath, [hwnd, rightPath](bool success){
+                if (success) {
+                    MarkCompareDirty();
+                }
+                if (!rightPath.empty() && rightPath != g_imagePath) {
+                    LoadImageAsync(hwnd, rightPath, false);
+                }
+            });
+        } else {
+            g_compare.left.Reset();
+            MarkCompareDirty();
+            if (!rightPath.empty() && rightPath != g_imagePath) {
+                LoadImageAsync(hwnd, rightPath, false);
+            }
+        }
+    } else {
+        CaptureCurrentImageAsCompareLeft();
+        if (!g_compare.left.valid) return;
+    }
 
     // [v6.8] Special Route: If soft-proofing is enabled, automatically compare Before vs After.
     if (g_runtime.EnableSoftProofing) {
@@ -12317,6 +12360,9 @@ void StartNavigation(HWND hwnd, std::wstring path, [[maybe_unused]] bool showOSD
         g_runtime.CmsModeOverride = -1;
     }
     
+    // Update Comic Mode state
+    g_toolbar.SetComicMode(g_navigator.GetArchive() != nullptr);
+
     g_imagePath = path; // Set target path immediately for UI consistency
     
     // [Fix] Restore OriginalFilePath when loading a new clean image.
@@ -12597,6 +12643,65 @@ FireAndForget LoadImageAsync(HWND hwnd, std::wstring path, bool showOSD, QuickVi
 
 
 void NavigateEdge(HWND hwnd, bool toLast) {
+    if (g_navigator.Count() <= 0) return;
+    if (!CheckUnsavedChanges(hwnd)) return;
+
+    if (IsCompareModeActive() && g_toolbar.IsComicMode()) {
+        int targetRightIndex = toLast ? (int)g_navigator.Count() - 1 : 0;
+
+        int nextRightIndex = (targetRightIndex + 1) & ~1;
+        int nextLeftIndex = nextRightIndex - 1;
+
+        std::wstring rightPath;
+        if (nextRightIndex >= 0 && nextRightIndex < (int)g_navigator.Count()) {
+            rightPath = g_navigator.GetFile(nextRightIndex);
+        }
+
+        std::wstring leftPath;
+        if (nextLeftIndex >= 0 && nextLeftIndex < (int)g_navigator.Count()) {
+            leftPath = g_navigator.GetFile(nextLeftIndex);
+        }
+
+        if (rightPath.empty() && leftPath.empty()) {
+            return;
+        }
+
+        if (rightPath.empty()) {
+            rightPath = leftPath;
+            leftPath = L"";
+            g_navigator.SetIndex(nextLeftIndex);
+        } else {
+            g_navigator.SetIndex(nextRightIndex);
+        }
+
+        g_compare.activePane = ComparePane::Right;
+        g_compare.contextPane = ComparePane::Right;
+        g_compare.selectedPane = ComparePane::Right;
+        g_editState.Reset();
+        if (!g_preserveViewStateOnNextLoad) {
+            g_viewState.Reset();
+        }
+
+        QuickView::BrowseDirection browseDir = toLast ? QuickView::BrowseDirection::FORWARD : QuickView::BrowseDirection::BACKWARD;
+
+        if (!leftPath.empty()) {
+            LoadImageIntoCompareLeftSlot(hwnd, leftPath, [hwnd, rightPath, browseDir](bool success){
+                if (success) {
+                    MarkCompareDirty();
+                }
+                if (!rightPath.empty()) {
+                    LoadImageAsync(hwnd, rightPath, true, browseDir);
+                }
+            });
+        } else {
+            g_compare.left.Reset();
+            MarkCompareDirty();
+            LoadImageAsync(hwnd, rightPath, true, browseDir);
+        }
+
+        return;
+    }
+
     if (IsCompareModeActive() && g_compare.selectedPane == ComparePane::Left) {
         if (!g_compare.left.valid || g_compare.left.path.empty()) return;
         FileNavigator tempNav;
@@ -12617,9 +12722,6 @@ void NavigateEdge(HWND hwnd, bool toLast) {
         }
         return;
     }
-
-    if (g_navigator.Count() <= 0) return;
-    if (!CheckUnsavedChanges(hwnd)) return;
 
     std::wstring path = (toLast)
         ? g_navigator.Last()
@@ -12652,6 +12754,82 @@ void NavigateEdge(HWND hwnd, bool toLast) {
 }
 
 void Navigate(HWND hwnd, int direction) {
+    if (g_navigator.Count() <= 0) return;
+    if (!CheckUnsavedChanges(hwnd)) return;
+
+    if (IsCompareModeActive() && g_toolbar.IsComicMode()) {
+        int currentIndex = g_navigator.Index();
+
+        if (direction > 0) {
+            if (currentIndex >= (int)g_navigator.Count() - 1) {
+                g_osd.Show(hwnd, std::wstring(AppStrings::OSD_LastImage), false);
+                return;
+            }
+        } else {
+            if (currentIndex <= 0) {
+                g_osd.Show(hwnd, std::wstring(AppStrings::OSD_FirstImage), false);
+                return;
+            }
+        }
+
+        int step = (direction > 0) ? 2 : -2;
+        int nextRightIndex = currentIndex + step;
+
+        // Force nextRightIndex to be EVEN
+        nextRightIndex = (nextRightIndex + 1) & ~1;
+
+        int nextLeftIndex = nextRightIndex - 1;
+
+        std::wstring rightPath;
+        if (nextRightIndex >= 0 && nextRightIndex < (int)g_navigator.Count()) {
+            rightPath = g_navigator.GetFile(nextRightIndex);
+        }
+
+        std::wstring leftPath;
+        if (nextLeftIndex >= 0 && nextLeftIndex < (int)g_navigator.Count()) {
+            leftPath = g_navigator.GetFile(nextLeftIndex);
+        }
+
+        if (rightPath.empty() && leftPath.empty()) {
+            return;
+        }
+
+        if (rightPath.empty()) {
+            rightPath = leftPath;
+            leftPath = L"";
+            g_navigator.SetIndex(nextLeftIndex);
+        } else {
+            g_navigator.SetIndex(nextRightIndex);
+        }
+
+        g_compare.activePane = ComparePane::Right;
+        g_compare.contextPane = ComparePane::Right;
+        g_compare.selectedPane = ComparePane::Right;
+        g_editState.Reset();
+        if (!g_preserveViewStateOnNextLoad) {
+            g_viewState.Reset();
+        }
+
+        QuickView::BrowseDirection browseDir = (direction > 0) ? QuickView::BrowseDirection::FORWARD : QuickView::BrowseDirection::BACKWARD;
+
+        if (!leftPath.empty()) {
+            LoadImageIntoCompareLeftSlot(hwnd, leftPath, [hwnd, rightPath, browseDir](bool success){
+                if (success) {
+                    MarkCompareDirty();
+                }
+                if (!rightPath.empty()) {
+                    LoadImageAsync(hwnd, rightPath, true, browseDir);
+                }
+            });
+        } else {
+            g_compare.left.Reset();
+            MarkCompareDirty();
+            LoadImageAsync(hwnd, rightPath, true, browseDir);
+        }
+
+        return;
+    }
+
     if (IsCompareModeActive() && g_compare.selectedPane == ComparePane::Left) {
         if (!g_compare.left.valid || g_compare.left.path.empty()) return;
         FileNavigator tempNav;
@@ -12678,9 +12856,6 @@ void Navigate(HWND hwnd, int direction) {
         }
         return;
     }
-
-    if (g_navigator.Count() <= 0) return;
-    if (!CheckUnsavedChanges(hwnd)) return;
 
     std::wstring path = (direction > 0)
         ? g_navigator.Next()


### PR DESCRIPTION
This pull request introduces a specialized Comic/E-Book viewing mode for archive files (`.cbz`, `.cbr`, `.zip`, `.rar`) by cleverly repurposing the existing Compare Mode architecture.

**Key Changes:**
1.  **Comic Mode Detection & UI Changes:**
    - Checks `g_navigator.GetArchive() != nullptr` to enable `m_comicMode` on the `Toolbar`.
    - Hides non-applicable options like Rotate, Flip, Exif, and secondary Compare Mode buttons on the toolbar.
    - Changes the `CompareToggle` icon to a `Layout` (book layout) icon to signify Dual Page Mode, adjusting tooltips respectively.
2.  **Simultaneous Dual Page Navigation:**
    - Modifies the main `Navigate` and `NavigateEdge` functions to intercept page turns when Comic Mode + Compare Mode are active.
    - Aligns pages by enforcing the main image to maintain an even index position. Pages are advanced in chunks of 2 while mapping the previous page to the `ComparePane::Left` buffer and the current page to the main context. This emulates standard Left-to-Right page folding semantics.
3.  **InfoPanel Lite Adjustments:**
    - Tweaked `UIRenderer::DrawCompactInfo` to display the active pagination string (`[Current Page / Total Pages]`) implicitly when the VFS is actively browsing an archive.
4.  **Error Prevention:**
    - Enforces proper `g_navigator.SetIndex()` calls to ensure sequential accuracy and maintain bounds matching between the view state and the VFS tracker.

---
*PR created automatically by Jules for task [6293385632260175612](https://jules.google.com/task/6293385632260175612) started by @justnullname*