### PR TITLE
Feature/raw jpeg pairing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,10 +313,11 @@ target_link_libraries(QuickView PRIVATE
 find_package(GTest CONFIG REQUIRED)
 enable_testing()
 
-add_executable(QuickViewTests 
-    tests/ColorMathTests.cpp 
-    tests/FileNavigatorTests.cpp 
+add_executable(QuickViewTests
+    tests/ColorMathTests.cpp
+    tests/FileNavigatorTests.cpp
     tests/HotkeyTests.cpp
+    tests/SupportedExtensionsTests.cpp
     QuickView/ColorMath.cpp 
     QuickView/FileNavigator.cpp 
     QuickView/ArchiveVFS.cpp 

--- a/QuickView/AppStrings.cpp
+++ b/QuickView/AppStrings.cpp
@@ -5648,6 +5648,20 @@ std::wstring GetHotkeyActionName(HotkeyAction action) {
     case HotkeyAction::RenderRaw:
         raw = AppStrings::Context_RenderRAW;
         break;
+    case HotkeyAction::ComparePair: {
+        needsCleaning = false;
+        switch (GetActiveLanguage()) {
+        case AppStrings::Language::ChineseSimplified:  raw = L"配对对比 (直出 vs RAW)"; break;
+        case AppStrings::Language::ChineseTraditional: raw = L"配對對比 (直出 vs RAW)"; break;
+        case AppStrings::Language::Japanese:           raw = L"ペア比較 (撮って出し vs RAW)"; break;
+        case AppStrings::Language::Russian:            raw = L"Сравнение пары (камерный снимок и RAW)"; break;
+        case AppStrings::Language::German:             raw = L"Paarvergleich (Kamerabild vs. RAW)"; break;
+        case AppStrings::Language::Spanish:            raw = L"Comparar par (imagen de cámara vs RAW)"; break;
+        case AppStrings::Language::French:             raw = L"Comparer la paire (image boîtier vs RAW)"; break;
+        default:                                       raw = L"Compare Pair (Rendered vs RAW)"; break;
+        }
+        break;
+    }
     case HotkeyAction::ToggleAnimation: {
         // Special case: returns concatenated string
         std::wstring play = CleanLabel(AppStrings::Toolbar_Tooltip_AnimPlay);

--- a/QuickView/AppStrings.cpp
+++ b/QuickView/AppStrings.cpp
@@ -337,6 +337,8 @@ const wchar_t *Context_SoftProofProfile = nullptr;
 const wchar_t *Context_SoftProofCustom = nullptr;
 const wchar_t *Settings_Value_ComingSoon = nullptr;
 const wchar_t *Settings_Label_ForceRaw = nullptr;
+const wchar_t *Settings_Label_PairRawJpeg = nullptr;
+const wchar_t *Settings_Tooltip_PairRawJpeg = nullptr;
 const wchar_t *Settings_Label_Exposure = nullptr;
 const wchar_t *Settings_Tooltip_Exposure = nullptr;
 const wchar_t *Settings_Label_AddToOpenWith = nullptr;
@@ -825,6 +827,8 @@ struct LanguageTable {
     const wchar_t *Context_SoftProofCustom;
     const wchar_t *Settings_Value_ComingSoon;
     const wchar_t *Settings_Label_ForceRaw;
+    const wchar_t *Settings_Label_PairRawJpeg;
+    const wchar_t *Settings_Tooltip_PairRawJpeg;
     const wchar_t *Settings_Label_Exposure;
     const wchar_t *Settings_Tooltip_Exposure;
     const wchar_t *Settings_Label_AddToOpenWith;
@@ -1310,6 +1314,8 @@ static const LanguageTable Table_EN = {
     L"Custom...", // Context_SoftProofCustom
     L"Coming Soon", // Settings_Value_ComingSoon
     L"Force RAW Decode", // Settings_Label_ForceRaw
+    L"RAW+JPEG Pairing", // Settings_Label_PairRawJpeg
+    L"Show a RAW file and its same-name camera image (JPEG/HEIF) as one photo.\nOnly the rendered image stays in the list, marked with the RAW format (e.g. +CR3); capture times are verified in the background and mismatched pairs are split.\nSwitch between the camera image and the RAW decode with the RAW toolbar button or its hotkey, or view both with the pair-compare hotkey.", // Settings_Tooltip_PairRawJpeg
     L"Exposure (Brightness)", // Settings_Label_Exposure
     L"Adjust image brightness (Exposure Compensation). Range: 0.18x to 10.0x.", // Settings_Tooltip_Exposure
     L"Add to Open With", // Settings_Label_AddToOpenWith
@@ -1795,6 +1801,8 @@ static const LanguageTable Table_CN = {
     L"自定义...", // Context_SoftProofCustom
     L"敬请期待", // Settings_Value_ComingSoon
     L"强制 RAW 解码", // Settings_Label_ForceRaw
+    L"RAW+JPEG 配对", // Settings_Label_PairRawJpeg
+    L"将 RAW 与同名的相机直出图 (JPEG/HEIF) 显示为同一张照片。\n列表中仅保留直出图，并标注 RAW 格式（如 +CR3）；后台会校验两者拍摄时间，不一致的配对自动拆开。\n可用 RAW 工具栏按钮或其热键切换相机直出和本机渲染，也可用配对对比热键并排查看。", // Settings_Tooltip_PairRawJpeg
     L"曝光度 (亮度)", // Settings_Label_Exposure
     L"调节图像亮度 (曝光补偿)。范围: 0.18x 至 10.0x。", // Settings_Tooltip_Exposure
     L"添加到打开方式", // Settings_Label_AddToOpenWith
@@ -2280,6 +2288,8 @@ static const LanguageTable Table_TW = {
     L"自訂...", // Context_SoftProofCustom
     L"敬請期待", // Settings_Value_ComingSoon
     L"強制 RAW 解碼", // Settings_Label_ForceRaw
+    L"RAW+JPEG 配對", // Settings_Label_PairRawJpeg
+    L"將 RAW 與同名的相機直出圖 (JPEG/HEIF) 顯示為同一張照片。\n清單中僅保留直出圖，並標註 RAW 格式（如 +CR3）；背景會校驗兩者拍攝時間，不一致的配對自動拆開。\n可用 RAW 工具列按鈕或其快速鍵切換相機直出與本機渲染，也可用配對比較快速鍵並排檢視。", // Settings_Tooltip_PairRawJpeg
     L"曝光度 (亮度)", // Settings_Label_Exposure
     L"調節圖像亮度 (曝光補償)。範圍: 0.18x 至 10.0x。", // Settings_Tooltip_Exposure
     L"新增至開啟方式", // Settings_Label_AddToOpenWith
@@ -2765,6 +2775,8 @@ static const LanguageTable Table_JA = {
     L"カスタム...", // Context_SoftProofCustom
     L"近日公開", // Settings_Value_ComingSoon
     L"RAW強制デコード", // Settings_Label_ForceRaw
+    L"RAW+JPEG ペアリング", // Settings_Label_PairRawJpeg
+    L"RAW と同名のカメラ撮って出し画像 (JPEG/HEIF) を 1 枚の写真として表示します。\n一覧には撮って出し画像のみが残り、RAW 形式 (+CR3 など) が表示されます。撮影時刻はバックグラウンドで照合され、一致しないペアは解除されます。\nRAW ツールバーボタンまたはそのホットキーで撮って出しと RAW デコード表示を切り替え、ペア比較ホットキーで並べて確認できます。", // Settings_Tooltip_PairRawJpeg
     L"露出 (明るさ)", // Settings_Label_Exposure
     L"画像の明るさを調整します (露出補正)。範囲: 0.18x ~ 10.0x。", // Settings_Tooltip_Exposure
     L"プログラムから開くに追加", // Settings_Label_AddToOpenWith
@@ -3250,6 +3262,8 @@ static const LanguageTable Table_RU = {
     L"Свой...", // Context_SoftProofCustom
     L"Скоро", // Settings_Value_ComingSoon
     L"Принудительное декодирование RAW", // Settings_Label_ForceRaw
+    L"Связывание RAW+JPEG", // Settings_Label_PairRawJpeg
+    L"Показывать RAW и одноимённый снимок камеры (JPEG/HEIF) как одну фотографию.\nВ списке остаётся только готовое изображение с пометкой формата RAW (например, +CR3); время съёмки проверяется в фоне, несовпадающие пары разделяются.\nКнопка RAW на панели или её горячая клавиша переключает между снимком камеры и декодированным RAW; горячая клавиша парного сравнения показывает обе версии рядом.", // Settings_Tooltip_PairRawJpeg
     L"Экспозиция (яркость)", // Settings_Label_Exposure
     L"Регулировка яркости изображения (компенсация экспозиции). Диапазон: 0.18x - 10.0x.", // Settings_Tooltip_Exposure
     L"Добавить в 'Открыть с помощью'", // Settings_Label_AddToOpenWith
@@ -3735,6 +3749,8 @@ static const LanguageTable Table_DE = {
     L"Benutzerdefiniert...", // Context_SoftProofCustom
     L"Demnächst", // Settings_Value_ComingSoon
     L"RAW erzwingen", // Settings_Label_ForceRaw
+    L"RAW+JPEG-Paarung", // Settings_Label_PairRawJpeg
+    L"Eine RAW-Datei und das gleichnamige Kamerabild (JPEG/HEIF) als ein Foto anzeigen.\nIn der Liste bleibt nur das gerenderte Bild, markiert mit dem RAW-Format (z. B. +CR3); Aufnahmezeiten werden im Hintergrund geprüft, abweichende Paare werden getrennt.\nMit dem RAW-Button oder seinem Hotkey zwischen Kamerabild und RAW-Dekodierung wechseln, mit dem Paarvergleich-Hotkey beide nebeneinander ansehen.", // Settings_Tooltip_PairRawJpeg
     L"Belichtung (Helligkeit)", // Settings_Label_Exposure
     L"Passt die Bildhelligkeit an (Belichtungskorrektur). Bereich: 0.18x bis 10.0x.", // Settings_Tooltip_Exposure
     L"Zu Öffnen mit hinzufügen", // Settings_Label_AddToOpenWith
@@ -4220,6 +4236,8 @@ static const LanguageTable Table_ES = {
     L"Personalizado...", // Context_SoftProofCustom
     L"Próximamente", // Settings_Value_ComingSoon
     L"Forzar decodificación RAW", // Settings_Label_ForceRaw
+    L"Emparejamiento RAW+JPEG", // Settings_Label_PairRawJpeg
+    L"Mostrar un archivo RAW y la imagen de cámara del mismo nombre (JPEG/HEIF) como una sola foto.\nEn la lista solo queda la imagen revelada, marcada con el formato RAW (p. ej. +CR3); las horas de captura se verifican en segundo plano y las parejas discordantes se separan.\nCambie entre la imagen de cámara y la decodificación RAW con el botón RAW o su atajo, o vea ambas con el atajo de comparación de pareja.", // Settings_Tooltip_PairRawJpeg
     L"Exposición (Brillo)", // Settings_Label_Exposure
     L"Ajusta el brillo de la imagen (compensación de exposición). Rango: 0.18x - 10.0x.", // Settings_Tooltip_Exposure
     L"Añadir a Abrir con", // Settings_Label_AddToOpenWith
@@ -4705,6 +4723,8 @@ static const LanguageTable Table_FR = {
     L"Personnalisé...", // Context_SoftProofCustom
     L"Bientôt disponible", // Settings_Value_ComingSoon
     L"Forcer le décodage RAW", // Settings_Label_ForceRaw
+    L"Appairage RAW+JPEG", // Settings_Label_PairRawJpeg
+    L"Afficher un fichier RAW et l'image boîtier du même nom (JPEG/HEIF) comme une seule photo.\nSeule l'image rendue reste dans la liste, marquée du format RAW (ex. +CR3) ; les heures de prise de vue sont vérifiées en arrière-plan et les paires discordantes sont séparées.\nBasculez entre l'image boîtier et le décodage RAW avec le bouton RAW ou son raccourci, ou affichez les deux avec le raccourci de comparaison de paire.", // Settings_Tooltip_PairRawJpeg
     L"Exposition (Luminosité)", // Settings_Label_Exposure
     L"Ajuste la luminosité de l'image (compensation d'exposition). Plage : 0.18x - 10.0x.", // Settings_Tooltip_Exposure
     L"Ajouter à 'Ouvrir avec'", // Settings_Label_AddToOpenWith
@@ -5190,6 +5210,8 @@ void Apply(const LanguageTable& t) {
   Context_SoftProofCustom = t.Context_SoftProofCustom;
   Settings_Value_ComingSoon = t.Settings_Value_ComingSoon;
   Settings_Label_ForceRaw = t.Settings_Label_ForceRaw;
+  Settings_Label_PairRawJpeg = t.Settings_Label_PairRawJpeg;
+  Settings_Tooltip_PairRawJpeg = t.Settings_Tooltip_PairRawJpeg;
   Settings_Label_Exposure = t.Settings_Label_Exposure;
   Settings_Tooltip_Exposure = t.Settings_Tooltip_Exposure;
   Settings_Label_AddToOpenWith = t.Settings_Label_AddToOpenWith;

--- a/QuickView/AppStrings.cpp
+++ b/QuickView/AppStrings.cpp
@@ -140,6 +140,8 @@ const wchar_t *Toolbar_Tooltip_Gallery = nullptr;
 const wchar_t *Toolbar_Tooltip_Info = nullptr;
 const wchar_t *Toolbar_Tooltip_RawPreview = nullptr;
 const wchar_t *Toolbar_Tooltip_RawFull = nullptr;
+const wchar_t *Toolbar_Tooltip_RawPairView = nullptr;
+const wchar_t *Toolbar_Tooltip_RawPairBack = nullptr;
 const wchar_t *Toolbar_Tooltip_FixExtension = nullptr;
 const wchar_t *Toolbar_Tooltip_Pin = nullptr;
 const wchar_t *Toolbar_Tooltip_Unpin = nullptr;
@@ -626,6 +628,8 @@ struct LanguageTable {
     const wchar_t *Toolbar_Tooltip_Info;
     const wchar_t *Toolbar_Tooltip_RawPreview;
     const wchar_t *Toolbar_Tooltip_RawFull;
+    const wchar_t *Toolbar_Tooltip_RawPairView;
+    const wchar_t *Toolbar_Tooltip_RawPairBack;
     const wchar_t *Toolbar_Tooltip_FixExtension;
     const wchar_t *Toolbar_Tooltip_Pin;
     const wchar_t *Toolbar_Tooltip_Unpin;
@@ -1109,6 +1113,8 @@ static const LanguageTable Table_EN = {
     L"Info Panel", // Toolbar_Tooltip_Info
     L"RAW: Preview (Click for Full)", // Toolbar_Tooltip_RawPreview
     L"RAW: Full Decode (Click for Preview)", // Toolbar_Tooltip_RawFull
+    L"RAW: View paired RAW (Full Decode)", // Toolbar_Tooltip_RawPairView
+    L"RAW: Back to paired image", // Toolbar_Tooltip_RawPairBack
     L"Extension Mismatch (Fix)", // Toolbar_Tooltip_FixExtension
     L"Pin Toolbar", // Toolbar_Tooltip_Pin
     L"Unpin Toolbar", // Toolbar_Tooltip_Unpin
@@ -1592,6 +1598,8 @@ static const LanguageTable Table_CN = {
     L"信息面板", // Toolbar_Tooltip_Info
     L"RAW: 快速预览 (点击切换完整)", // Toolbar_Tooltip_RawPreview
     L"RAW: 完整解码 (点击切换预览)", // Toolbar_Tooltip_RawFull
+    L"RAW: 查看配对 RAW (完整解码)", // Toolbar_Tooltip_RawPairView
+    L"RAW: 返回配对图像", // Toolbar_Tooltip_RawPairBack
     L"扩展名不匹配 (修复)", // Toolbar_Tooltip_FixExtension
     L"固定工具栏", // Toolbar_Tooltip_Pin
     L"取消固定工具栏", // Toolbar_Tooltip_Unpin
@@ -2075,6 +2083,8 @@ static const LanguageTable Table_TW = {
     L"資訊面板", // Toolbar_Tooltip_Info
     L"RAW: 快速預覽 (點選切換完整)", // Toolbar_Tooltip_RawPreview
     L"RAW: 完整解碼 (點選切換預覽)", // Toolbar_Tooltip_RawFull
+    L"RAW: 檢視配對 RAW (完整解碼)", // Toolbar_Tooltip_RawPairView
+    L"RAW: 返回配對圖像", // Toolbar_Tooltip_RawPairBack
     L"副檔名不符 (修復)", // Toolbar_Tooltip_FixExtension
     L"固定工具列", // Toolbar_Tooltip_Pin
     L"取消固定工具列", // Toolbar_Tooltip_Unpin
@@ -2558,6 +2568,8 @@ static const LanguageTable Table_JA = {
     L"情報パネル", // Toolbar_Tooltip_Info
     L"RAW: プレビュー (クリックでフル)", // Toolbar_Tooltip_RawPreview
     L"RAW: フルデコード (クリックでプレビュー)", // Toolbar_Tooltip_RawFull
+    L"RAW: ペアのRAWを表示 (フルデコード)", // Toolbar_Tooltip_RawPairView
+    L"RAW: ペア画像に戻る", // Toolbar_Tooltip_RawPairBack
     L"拡張子不一致 (修正)", // Toolbar_Tooltip_FixExtension
     L"ツールバーを固定", // Toolbar_Tooltip_Pin
     L"ツールバーの固定を解除", // Toolbar_Tooltip_Unpin
@@ -3041,6 +3053,8 @@ static const LanguageTable Table_RU = {
     L"Информационная панель", // Toolbar_Tooltip_Info
     L"RAW: Предпросмотр (нажмите для полного)", // Toolbar_Tooltip_RawPreview
     L"RAW: Полное декодирование (нажмите для предпросмотра)", // Toolbar_Tooltip_RawFull
+    L"RAW: Показать парный RAW (полное декодирование)", // Toolbar_Tooltip_RawPairView
+    L"RAW: Вернуться к парному изображению", // Toolbar_Tooltip_RawPairBack
     L"Несоответствие расширения (исправить)", // Toolbar_Tooltip_FixExtension
     L"Закрепить панель", // Toolbar_Tooltip_Pin
     L"Открепить панель", // Toolbar_Tooltip_Unpin
@@ -3524,6 +3538,8 @@ static const LanguageTable Table_DE = {
     L"Info-Panel", // Toolbar_Tooltip_Info
     L"RAW: Vorschau (Klick für Voll)", // Toolbar_Tooltip_RawPreview
     L"RAW: Volle Dekodierung (Klick für Vorschau)", // Toolbar_Tooltip_RawFull
+    L"RAW: Gepaartes RAW anzeigen (volle Dekodierung)", // Toolbar_Tooltip_RawPairView
+    L"RAW: Zurück zum gepaarten Bild", // Toolbar_Tooltip_RawPairBack
     L"Erweiterung stimmt nicht (Reparieren)", // Toolbar_Tooltip_FixExtension
     L"Symbolleiste anheften", // Toolbar_Tooltip_Pin
     L"Symbolleiste lösen", // Toolbar_Tooltip_Unpin
@@ -4007,6 +4023,8 @@ static const LanguageTable Table_ES = {
     L"Panel de información", // Toolbar_Tooltip_Info
     L"RAW: Vista previa (Clic para completo)", // Toolbar_Tooltip_RawPreview
     L"RAW: Decodificación completa (Clic para vista previa)", // Toolbar_Tooltip_RawFull
+    L"RAW: Ver RAW emparejado (decodificación completa)", // Toolbar_Tooltip_RawPairView
+    L"RAW: Volver a la imagen emparejada", // Toolbar_Tooltip_RawPairBack
     L"Extensión no coincide (Reparar)", // Toolbar_Tooltip_FixExtension
     L"Fijar barra de herramientas", // Toolbar_Tooltip_Pin
     L"Soltar barra de herramientas", // Toolbar_Tooltip_Unpin
@@ -4490,6 +4508,8 @@ static const LanguageTable Table_FR = {
     L"Info Panel", // Toolbar_Tooltip_Info
     L"RAW: Preview (Click for Full)", // Toolbar_Tooltip_RawPreview
     L"RAW: Full Decode (Click for Preview)", // Toolbar_Tooltip_RawFull
+    L"RAW : Voir le RAW associé (décodage complet)", // Toolbar_Tooltip_RawPairView
+    L"RAW : Revenir à l'image associée", // Toolbar_Tooltip_RawPairBack
     L"Extension Mismatch (Fix)", // Toolbar_Tooltip_FixExtension
     L"Pin Toolbar", // Toolbar_Tooltip_Pin
     L"Unpin Toolbar", // Toolbar_Tooltip_Unpin
@@ -4973,6 +4993,8 @@ void Apply(const LanguageTable& t) {
   Toolbar_Tooltip_Info = t.Toolbar_Tooltip_Info;
   Toolbar_Tooltip_RawPreview = t.Toolbar_Tooltip_RawPreview;
   Toolbar_Tooltip_RawFull = t.Toolbar_Tooltip_RawFull;
+  Toolbar_Tooltip_RawPairView = t.Toolbar_Tooltip_RawPairView;
+  Toolbar_Tooltip_RawPairBack = t.Toolbar_Tooltip_RawPairBack;
   Toolbar_Tooltip_FixExtension = t.Toolbar_Tooltip_FixExtension;
   Toolbar_Tooltip_Pin = t.Toolbar_Tooltip_Pin;
   Toolbar_Tooltip_Unpin = t.Toolbar_Tooltip_Unpin;
@@ -5622,6 +5644,9 @@ std::wstring GetHotkeyActionName(HotkeyAction action) {
         break;
     case HotkeyAction::FlipV:
         raw = AppStrings::Context_FlipV;
+        break;
+    case HotkeyAction::RenderRaw:
+        raw = AppStrings::Context_RenderRAW;
         break;
     case HotkeyAction::ToggleAnimation: {
         // Special case: returns concatenated string

--- a/QuickView/AppStrings.h
+++ b/QuickView/AppStrings.h
@@ -119,6 +119,8 @@ namespace AppStrings {
     extern const wchar_t* Toolbar_Tooltip_Info;
     extern const wchar_t* Toolbar_Tooltip_RawPreview; // Fast
     extern const wchar_t* Toolbar_Tooltip_RawFull;    // Full
+    extern const wchar_t* Toolbar_Tooltip_RawPairView; // Paired item: switch to the RAW
+    extern const wchar_t* Toolbar_Tooltip_RawPairBack; // Paired RAW view: back to rendered
     extern const wchar_t* Toolbar_Tooltip_FixExtension;
     extern const wchar_t* Toolbar_Tooltip_Pin;
     extern const wchar_t* Toolbar_Tooltip_Unpin;

--- a/QuickView/AppStrings.h
+++ b/QuickView/AppStrings.h
@@ -416,6 +416,8 @@ namespace AppStrings {
     extern const wchar_t* Context_SoftProofCustom;
     extern const wchar_t* Settings_Value_ComingSoon;
     extern const wchar_t* Settings_Label_ForceRaw;
+    extern const wchar_t* Settings_Label_PairRawJpeg;
+    extern const wchar_t* Settings_Tooltip_PairRawJpeg;
     extern const wchar_t* Settings_Label_Exposure;
     extern const wchar_t* Settings_Tooltip_Exposure;
     extern const wchar_t* Settings_Label_AddToOpenWith;

--- a/QuickView/CompareController.cpp
+++ b/QuickView/CompareController.cpp
@@ -7,6 +7,7 @@
 #include "OSDState.h"
 #include "ImageTypes.h"
 #include "ImageResource.h"
+#include "SupportedExtensions.h"
 
 
 extern bool g_isLeftPaneDecoding;
@@ -54,7 +55,6 @@ extern Toolbar g_toolbar;
 extern std::unique_ptr<CRenderEngine> g_renderEngine;
 extern std::unique_ptr<UIRenderer> g_uiRenderer;
 extern void AdjustWindowToImage(HWND hwnd);
-extern bool IsRawFile(const std::wstring& path);
 
 CompareController::CompareController(AppContext& context) : m_context(context) {}
 
@@ -217,8 +217,8 @@ bool CompareController::IsNearCompareDivider(HWND hwnd, POINT ptClient, float th
 }
 
 void CompareController::UpdateRawButton() {
-    bool leftIsRaw = !GetPaneContext(PaneSlot::Left).path.empty() && IsRawFile(GetPaneContext(PaneSlot::Left).path);
-    bool rightIsRaw = !GetPaneContext(PaneSlot::Primary).path.empty() && IsRawFile(GetPaneContext(PaneSlot::Primary).path);
+    bool leftIsRaw = !GetPaneContext(PaneSlot::Left).path.empty() && QuickView::IsRawPath(GetPaneContext(PaneSlot::Left).path);
+    bool rightIsRaw = !GetPaneContext(PaneSlot::Primary).path.empty() && QuickView::IsRawPath(GetPaneContext(PaneSlot::Primary).path);
     bool anyRaw = leftIsRaw || rightIsRaw;
     bool selectedIsRaw = (m_context.Compare.selectedPane == ComparePane::Left) ? leftIsRaw : rightIsRaw;
     
@@ -739,12 +739,12 @@ bool CompareController::GetPaneRawState(ComparePane pane, bool& isRaw, bool& isF
     }
 
     if (pane == ComparePane::Left) {
-        isRaw = !GetPaneContext(PaneSlot::Left).path.empty() && IsRawFile(GetPaneContext(PaneSlot::Left).path);
+        isRaw = !GetPaneContext(PaneSlot::Left).path.empty() && QuickView::IsRawPath(GetPaneContext(PaneSlot::Left).path);
         isFullDecode = isRaw && GetPaneContext(PaneSlot::Left).metadata.IsRawFullDecode;
         return GetPaneContext(PaneSlot::Left).valid;
     }
 
-    isRaw = !GetPaneContext(PaneSlot::Primary).path.empty() && IsRawFile(GetPaneContext(PaneSlot::Primary).path);
+    isRaw = !GetPaneContext(PaneSlot::Primary).path.empty() && QuickView::IsRawPath(GetPaneContext(PaneSlot::Primary).path);
     isFullDecode = isRaw && GetPaneContext(PaneSlot::Primary).metadata.IsRawFullDecode;
     return static_cast<bool>(GetPaneContext(PaneSlot::Primary).resource);
 }

--- a/QuickView/EditState.h
+++ b/QuickView/EditState.h
@@ -144,6 +144,7 @@ enum class HotkeyAction : uint8_t {
     ToggleFullscreen,  // Toggle Fullscreen
     ToggleSpan,        // Toggle Span Displays
     ToggleSlideshow,   // Toggle Slideshow Mode
+    RenderRaw,         // Toggle RAW decode / switch to the paired RAW
     OpenFile,          // Open File Dialog
     EditFile,          // Edit with External Editor
     RenameFile,        // Rename File Dialog
@@ -181,6 +182,7 @@ inline std::wstring_view HotkeyActionToString(HotkeyAction action) noexcept {
         case HotkeyAction::RotateCCW: return L"RotateCCW";
         case HotkeyAction::FlipH: return L"FlipH";
         case HotkeyAction::FlipV: return L"FlipV";
+        case HotkeyAction::RenderRaw: return L"RenderRaw";
         case HotkeyAction::ToggleAnimation: return L"ToggleAnimation";
         case HotkeyAction::AnimNextFrame: return L"AnimNextFrame";
         case HotkeyAction::AnimPrevFrame: return L"AnimPrevFrame";
@@ -226,6 +228,7 @@ inline HotkeyAction StringToHotkeyAction(std::wstring_view sv) noexcept {
     if (sv == L"RotateCCW") return HotkeyAction::RotateCCW;
     if (sv == L"FlipH") return HotkeyAction::FlipH;
     if (sv == L"FlipV") return HotkeyAction::FlipV;
+    if (sv == L"RenderRaw") return HotkeyAction::RenderRaw;
     if (sv == L"ToggleAnimation") return HotkeyAction::ToggleAnimation;
     if (sv == L"AnimNextFrame") return HotkeyAction::AnimNextFrame;
     if (sv == L"AnimPrevFrame") return HotkeyAction::AnimPrevFrame;

--- a/QuickView/EditState.h
+++ b/QuickView/EditState.h
@@ -152,6 +152,7 @@ enum class HotkeyAction : uint8_t {
     CopyImage,         // Copy Image to Clipboard
     CopyPath,          // Copy Path to Clipboard
     ToggleCompare,     // Toggle Compare Mode
+    ComparePair,       // Compare a pair: rendered vs RAW side by side
     AlwaysOnTop,       // Toggle Always on Top
     ToggleDebugHud,    // Toggle Debug Performance HUD
     Print,             // Print Image
@@ -198,6 +199,7 @@ inline std::wstring_view HotkeyActionToString(HotkeyAction action) noexcept {
         case HotkeyAction::CopyImage: return L"CopyImage";
         case HotkeyAction::CopyPath: return L"CopyPath";
         case HotkeyAction::ToggleCompare: return L"ToggleCompare";
+        case HotkeyAction::ComparePair: return L"ComparePair";
         case HotkeyAction::AlwaysOnTop: return L"AlwaysOnTop";
         case HotkeyAction::ToggleDebugHud: return L"ToggleDebugHud";
         case HotkeyAction::Print: return L"Print";
@@ -244,6 +246,7 @@ inline HotkeyAction StringToHotkeyAction(std::wstring_view sv) noexcept {
     if (sv == L"CopyImage") return HotkeyAction::CopyImage;
     if (sv == L"CopyPath") return HotkeyAction::CopyPath;
     if (sv == L"ToggleCompare") return HotkeyAction::ToggleCompare;
+    if (sv == L"ComparePair") return HotkeyAction::ComparePair;
     if (sv == L"AlwaysOnTop") return HotkeyAction::AlwaysOnTop;
     if (sv == L"ToggleDebugHud") return HotkeyAction::ToggleDebugHud;
     if (sv == L"Print") return HotkeyAction::Print;

--- a/QuickView/EditState.h
+++ b/QuickView/EditState.h
@@ -621,9 +621,14 @@ struct AppConfig {
     // Default States (User Preference)
     bool ShowInfoPanel = false;          
     bool InfoPanelExpanded = false;      
-    bool ForceRawDecode = false;         
+    bool ForceRawDecode = false;
     bool RenderRAW = false;
-    
+
+    // [RAW+JPEG Pairing] Merge a same-name RAW + camera-rendered JPEG/HEIF into
+    // one logical photo (the RAW is hidden from the list). Default off so
+    // behavior is identical to stock unless the user opts in.
+    bool PairRawJpeg = false;
+
     /// <summary>
     bool IsAdvancedColorEnabled(bool isSystemHdrActive) const {
         return AdvancedColorMode == 1 || (AdvancedColorMode == 2 && isSystemHdrActive);

--- a/QuickView/FileNavigator.cpp
+++ b/QuickView/FileNavigator.cpp
@@ -47,7 +47,7 @@ void FileNavigator::Initialize(const std::wstring& currentPath, HWND hwnd) {
     std::wstring pExt = p.extension().wstring();
     std::transform(pExt.begin(), pExt.end(), pExt.begin(), [](wchar_t c){ return std::towlower(c); });
 
-    if (pExt == L".cbz" || pExt == L".zip" || pExt == L".cbr" || pExt == L".rar") {
+    if (QuickView::IsArchiveExtension(pExt)) {
         // Load from Archive VFS
         m_archivePath = p.wstring();
         if (pExt == L".cbr" || pExt == L".rar") {
@@ -94,7 +94,7 @@ void FileNavigator::Initialize(const std::wstring& currentPath, HWND hwnd) {
                 std::transform(ext.begin(), ext.end(), ext.begin(), [](wchar_t c){ return std::towlower(c); });
 
                 // Skip archive container files from the flat folder slideshow playlist
-                bool isArchiveExt = (ext == L".cbz" || ext == L".zip" || ext == L".cbr" || ext == L".rar");
+                bool isArchiveExt = QuickView::IsArchiveExtension(ext);
                 if (isArchiveExt) continue;
 
                 for (const auto& supp : QuickView::SUPPORTED_EXTENSIONS) {
@@ -540,7 +540,7 @@ __declspec(noinline) std::vector<std::wstring> FileNavigator::GetSortedSiblings(
         } else if (entry.is_regular_file(ec)) {
             std::wstring ext = entry.path().extension().wstring();
             std::transform(ext.begin(), ext.end(), ext.begin(), [](wchar_t c){ return std::towlower(c); });
-            bool isArchive = (ext == L".cbz" || ext == L".zip" || ext == L".cbr" || ext == L".rar");
+            bool isArchive = QuickView::IsArchiveExtension(ext);
             if (isArchive) {
                 siblings.push_back(entry.path().wstring());
                 continue;
@@ -599,7 +599,7 @@ std::wstring FileNavigator::FindAdjacentFolderImage(bool next) {
         } else {
             std::wstring sibExt = fs::path(sib).extension().wstring();
             std::transform(sibExt.begin(), sibExt.end(), sibExt.begin(), [](wchar_t c){ return std::towlower(c); });
-            if (sibExt == L".cbz" || sibExt == L".zip" || sibExt == L".cbr" || sibExt == L".rar") {
+            if (QuickView::IsArchiveExtension(sibExt)) {
                 isContainer = true;
             }
         }
@@ -639,7 +639,7 @@ FileNavigator::DirectoryScanResult FileNavigator::PerformDirectoryScan() {
             std::transform(ext.begin(), ext.end(), ext.begin(), [](wchar_t c){ return std::towlower(c); });
 
             // Skip archive container files from the flat folder slideshow playlist
-            bool isArchiveExt = (ext == L".cbz" || ext == L".zip" || ext == L".cbr" || ext == L".rar");
+            bool isArchiveExt = QuickView::IsArchiveExtension(ext);
             if (isArchiveExt) continue;
 
             for (const auto& supp : QuickView::SUPPORTED_EXTENSIONS) {

--- a/QuickView/FileNavigator.cpp
+++ b/QuickView/FileNavigator.cpp
@@ -7,7 +7,8 @@ extern AppConfig g_config;
 // defined in header: constexpr UINT WM_NAVIGATOR_DIR_CHANGED = WM_APP + 50;
 
 void FileNavigator::Initialize(const std::wstring& currentPath, HWND hwnd) {
-    // Stop existing watcher before mutating state
+    // Stop existing watcher and pair verification before mutating state
+    StopPairVerification();
     StopDirectoryWatcher();
     if (hwnd) m_hwnd = hwnd;
 
@@ -32,6 +33,17 @@ void FileNavigator::Initialize(const std::wstring& currentPath, HWND hwnd) {
     // If a directory is passed in, scan it directly. Otherwise scan the parent directory.
     fs::path dir = isDirectory ? p : p.parent_path();
     if (dir.empty()) return;
+
+    // [RAW+JPEG Pairing] Verification results belong to one folder
+    {
+        std::wstring dirStr = dir.wstring();
+        if (_wcsicmp(dirStr.c_str(), m_verifyDir.c_str()) != 0) {
+            std::lock_guard<std::mutex> lock(m_verifyMutex);
+            m_verifyDone.clear();
+            m_verifyUnpaired.clear();
+            m_verifyDir = std::move(dirStr);
+        }
+    }
 
     // Supported extensions (comprehensive list including RAW formats)
     // using QuickView::SUPPORTED_EXTENSIONS from SupportedExtensions.h
@@ -163,7 +175,12 @@ void FileNavigator::Initialize(const std::wstring& currentPath, HWND hwnd) {
     // only; archives are never paired)
     m_pairedRaws.clear();
     if (g_config.PairRawJpeg && !m_archive) {
-        ApplyRawJpegPairing(entries, m_pairedRaws);
+        std::unordered_set<ImageID> skip;
+        {
+            std::lock_guard<std::mutex> lock(m_verifyMutex);
+            skip = m_verifyUnpaired;
+        }
+        ApplyRawJpegPairing(entries, m_pairedRaws, skip.empty() ? nullptr : &skip);
     }
 
     // Write back
@@ -224,6 +241,9 @@ void FileNavigator::Initialize(const std::wstring& currentPath, HWND hwnd) {
             StartDirectoryWatcher(watchDir);
         }
     }
+
+    // [RAW+JPEG Pairing] Kick off capture-time verification for fresh pairs
+    StartPairVerification();
 }
 
 std::wstring FileNavigator::Next(bool /*unused*/) {
@@ -526,10 +546,120 @@ void FileNavigator::ApplyPendingScanResult() {
             }
         }
     }
+
+    // [RAW+JPEG Pairing] A rescan may have folded new pairs -- verify them.
+    // Already-verified pairs are skipped, so this cannot loop.
+    StartPairVerification();
+}
+
+int64_t FileNavigator::ParseExifDateTime(const std::string& exifDateTime) {
+    int y = 0, mo = 0, d = 0, h = 0, mi = 0, se = 0;
+    if (sscanf_s(exifDateTime.c_str(), "%d:%d:%d %d:%d:%d", &y, &mo, &d, &h, &mi, &se) != 6) return 0;
+    if (y < 1970 || y > 3000 || mo < 1 || mo > 12 || d < 1 || d > 31) return 0;
+    std::tm t{};
+    t.tm_year = y - 1900;
+    t.tm_mon = mo - 1;
+    t.tm_mday = d;
+    t.tm_hour = h;
+    t.tm_min = mi;
+    t.tm_sec = se;
+    t.tm_isdst = -1;
+    const time_t tt = std::mktime(&t); // local time, matching LibRaw's own conversion
+    return tt <= 0 ? 0 : (int64_t)tt;
+}
+
+// [RAW+JPEG Pairing] Capture time (DateTimeOriginal) of a JPEG file via
+// easyexif (a JPEG-only parser: exif.cpp rejects anything not starting with
+// FFD8); 0 when unreadable.
+static int64_t ReadJpegCaptureTime(const std::wstring& path) {
+    FILE* fp = nullptr;
+    _wfopen_s(&fp, path.c_str(), L"rb");
+    if (!fp) return 0;
+    unsigned char buf[65536];
+    size_t bytes = fread(buf, 1, sizeof(buf), fp);
+    fclose(fp);
+    if (bytes == 0) return 0;
+    easyexif::EXIFInfo info;
+    if (info.parseFrom(buf, (unsigned)bytes) != PARSE_EXIF_SUCCESS) return 0;
+    return FileNavigator::ParseExifDateTime(info.DateTimeOriginal);
+}
+
+void FileNavigator::StartPairVerification() {
+    if (!m_hwnd || m_pairedRaws.empty() || m_watchedDir.empty()) return;
+
+    // Snapshot the pairs that still need a capture-time check
+    struct VerifyItem {
+        std::wstring renderedPath;
+        std::wstring rawPath;
+        ImageID renderedId = 0;
+    };
+    std::vector<VerifyItem> todo;
+    {
+        std::lock_guard<std::mutex> lock(m_verifyMutex);
+        for (const auto& [renderedId, raw] : m_pairedRaws) {
+            if (m_verifyDone.find(renderedId) != m_verifyDone.end()) continue;
+            for (size_t i = 0; i < m_ids.size(); ++i) {
+                if (m_ids[i] == renderedId) {
+                    todo.push_back({ m_files[i], raw.path, renderedId });
+                    break;
+                }
+            }
+        }
+    }
+    if (todo.empty()) return;
+
+    StopPairVerification();
+    const uint32_t gen = ++m_verifyGeneration;
+    m_verifyThread = std::thread([this, gen, todo = std::move(todo)]() {
+        bool anyUnpaired = false;
+        for (const auto& item : todo) {
+            if (m_verifyGeneration.load() != gen) return; // superseded
+
+            // Rendered side: dispatch by extension -- JPEG through easyexif
+            // (fastest), everything else (HEIF) straight to the fallback
+            // reader (WIC). A JPEG whose date lives only in XMP gets one WIC
+            // retry too.
+            const std::wstring_view rext = QuickView::ExtensionOf(item.renderedPath);
+            const bool isJpeg = QuickView::ExtEqualsIgnoreCase(rext, L".jpg")
+                             || QuickView::ExtEqualsIgnoreCase(rext, L".jpeg");
+            int64_t tRendered = isJpeg ? ReadJpegCaptureTime(item.renderedPath) : 0;
+            if (tRendered == 0 && s_captureTimeFallback) {
+                tRendered = s_captureTimeFallback(item.renderedPath.c_str());
+            }
+
+            // RAW side: always the fallback reader (LibRaw branch)
+            const int64_t tRaw = s_captureTimeFallback ? s_captureTimeFallback(item.rawPath.c_str()) : 0;
+
+            std::lock_guard<std::mutex> lock(m_verifyMutex);
+            m_verifyDone.insert(item.renderedId);
+            if (PairVerificationFails(tRendered, tRaw)) {
+                m_verifyUnpaired.insert(item.renderedId);
+                anyUnpaired = true;
+            }
+        }
+        if (!anyUnpaired || m_verifyGeneration.load() != gen) return;
+
+        // Split the mismatched pairs back up: rescan with the blacklist in
+        // effect and hand the result to the main thread through the exact
+        // channel the directory watcher already uses (one atomic list swap).
+        DirectoryScanResult result = PerformDirectoryScan();
+        if (m_verifyGeneration.load() != gen) return;
+        {
+            std::lock_guard<std::mutex> lock(m_scanResultMutex);
+            m_pendingScanResult = std::move(result);
+        }
+        PostMessageW(m_hwnd, WM_NAVIGATOR_DIR_CHANGED, 0, 0);
+    });
+}
+
+void FileNavigator::StopPairVerification() {
+    ++m_verifyGeneration; // cancel the running pass, if any
+    if (m_verifyThread.joinable()) m_verifyThread.join();
 }
 
 void FileNavigator::ApplyRawJpegPairing(std::vector<SortEntry>& entries,
-                                        std::unordered_map<ImageID, PairedRaw>& outPairedRaws) {
+                                        std::unordered_map<ImageID, PairedRaw>& outPairedRaws,
+                                        const std::unordered_set<ImageID>* skipRendered) {
     outPairedRaws.clear();
 
     // Early exit: pairing is only possible when the folder mixes camera RAWs
@@ -578,7 +708,10 @@ void FileNavigator::ApplyRawJpegPairing(std::vector<SortEntry>& entries,
         if (g.rawCount != 1 || g.renderedCount != 1) continue;
         const SortEntry& raw = entries[g.rawIdx];
         const SortEntry& rendered = entries[g.renderedIdx];
-        outPairedRaws.emplace(ComputePathHash(rendered.p),
+        const ImageID renderedId = ComputePathHash(rendered.p);
+        // Capture-time verification confirmed these are different shots
+        if (skipRendered && skipRendered->find(renderedId) != skipRendered->end()) continue;
+        outPairedRaws.emplace(renderedId,
                               PairedRaw{ raw.p, raw.s, ComputePathHash(raw.p) });
         hide[g.rawIdx] = 1;
     }
@@ -813,7 +946,12 @@ FileNavigator::DirectoryScanResult FileNavigator::PerformDirectoryScan() {
 
     // [RAW+JPEG Pairing] Same fold as Initialize (watcher rescan path)
     if (g_config.PairRawJpeg) {
-        ApplyRawJpegPairing(entries, result.pairedRaws);
+        std::unordered_set<ImageID> skip;
+        {
+            std::lock_guard<std::mutex> lock(m_verifyMutex);
+            skip = m_verifyUnpaired;
+        }
+        ApplyRawJpegPairing(entries, result.pairedRaws, skip.empty() ? nullptr : &skip);
     }
 
     result.files.clear();

--- a/QuickView/FileNavigator.cpp
+++ b/QuickView/FileNavigator.cpp
@@ -552,6 +552,19 @@ void FileNavigator::ApplyPendingScanResult() {
     StartPairVerification();
 }
 
+void FileNavigator::RescanDirectory() {
+    if (m_watchedDir.empty()) return; // archive or no folder open
+    // Join any in-flight verification pass first: it could otherwise post a
+    // result computed before this one right after it.
+    StopPairVerification();
+    DirectoryScanResult result = PerformDirectoryScan();
+    {
+        std::lock_guard<std::mutex> lock(m_scanResultMutex);
+        m_pendingScanResult = std::move(result);
+    }
+    ApplyPendingScanResult();
+}
+
 int64_t FileNavigator::ParseExifDateTime(const std::string& exifDateTime) {
     int y = 0, mo = 0, d = 0, h = 0, mi = 0, se = 0;
     if (sscanf_s(exifDateTime.c_str(), "%d:%d:%d %d:%d:%d", &y, &mo, &d, &h, &mi, &se) != 6) return 0;

--- a/QuickView/FileNavigator.cpp
+++ b/QuickView/FileNavigator.cpp
@@ -158,7 +158,14 @@ void FileNavigator::Initialize(const std::wstring& currentPath, HWND hwnd) {
     }
 
     SortEntries(entries, sortOrder, sortDesc);
-    
+
+    // [RAW+JPEG Pairing] Fold same-name RAW + rendered pairs (real folders
+    // only; archives are never paired)
+    m_pairedRaws.clear();
+    if (g_config.PairRawJpeg && !m_archive) {
+        ApplyRawJpegPairing(entries, m_pairedRaws);
+    }
+
     // Write back
     m_files.clear();
     m_sizes.clear();
@@ -189,6 +196,22 @@ void FileNavigator::Initialize(const std::wstring& currentPath, HWND hwnd) {
                 if (m_files[i] == currentFull) {
                     m_currentIndex = (int)i;
                     break;
+                }
+            }
+
+            // [RAW+JPEG Pairing] The opened file may be a RAW folded behind
+            // its rendered sibling -- land on the pair instead.
+            if (m_currentIndex < 0 && !m_pairedRaws.empty()) {
+                for (const auto& [renderedId, raw] : m_pairedRaws) {
+                    if (raw.path == currentFull) {
+                        for (size_t i = 0; i < m_ids.size(); ++i) {
+                            if (m_ids[i] == renderedId) {
+                                m_currentIndex = (int)i;
+                                break;
+                            }
+                        }
+                        break;
+                    }
                 }
             }
         }
@@ -395,6 +418,21 @@ std::wstring FileNavigator::GetResolvedPath(const std::wstring& requestedPath) c
             return m_files[m_currentIndex];
         }
     }
+
+    // [RAW+JPEG Pairing] A RAW folded behind its rendered sibling resolves to
+    // that sibling: with pairing enabled the pair is one logical photo and the
+    // rendered file is its visible face, regardless of which file was opened.
+    if (!m_pairedRaws.empty()) {
+        for (const auto& [renderedId, raw] : m_pairedRaws) {
+            if (raw.path == requestedPath) {
+                for (size_t i = 0; i < m_ids.size(); ++i) {
+                    if (m_ids[i] == renderedId) return m_files[i];
+                }
+                break;
+            }
+        }
+    }
+
     return requestedPath;
 }
 
@@ -454,6 +492,7 @@ void FileNavigator::ApplyPendingScanResult() {
     m_files = std::move(result.files);
     m_sizes = std::move(result.sizes);
     m_ids = std::move(result.ids);
+    m_pairedRaws = std::move(result.pairedRaws);
 
     // Relocate current index in new list
     if (!currentPath.empty()) {
@@ -461,13 +500,97 @@ void FileNavigator::ApplyPendingScanResult() {
         if (it != m_files.end()) {
             m_currentIndex = (int)std::distance(m_files.begin(), it);
         } else {
-            // Fallback: file was deleted externally — clamp to nearest valid index
-            if (m_currentIndex >= (int)m_files.size()) {
-                m_currentIndex = (int)m_files.size() - 1;
+            // [RAW+JPEG Pairing] The viewed RAW may have just been folded
+            // behind its rendered sibling (e.g. its JPG appeared on disk) --
+            // relocate to the pair instead of clamping.
+            bool redirected = false;
+            for (const auto& [renderedId, raw] : m_pairedRaws) {
+                if (raw.path == currentPath) {
+                    for (size_t i = 0; i < m_ids.size(); ++i) {
+                        if (m_ids[i] == renderedId) {
+                            m_currentIndex = (int)i;
+                            redirected = true;
+                            break;
+                        }
+                    }
+                    break;
+                }
             }
-            if (m_files.empty()) m_currentIndex = -1;
+
+            // Fallback: file was deleted externally — clamp to nearest valid index
+            if (!redirected) {
+                if (m_currentIndex >= (int)m_files.size()) {
+                    m_currentIndex = (int)m_files.size() - 1;
+                }
+                if (m_files.empty()) m_currentIndex = -1;
+            }
         }
     }
+}
+
+void FileNavigator::ApplyRawJpegPairing(std::vector<SortEntry>& entries,
+                                        std::unordered_map<ImageID, PairedRaw>& outPairedRaws) {
+    outPairedRaws.clear();
+
+    // Early exit: pairing is only possible when the folder mixes camera RAWs
+    // with whitelisted rendered stills. One cheap in-memory pass, no I/O.
+    bool anyRaw = false, anyRendered = false;
+    for (const auto& e : entries) {
+        anyRaw = anyRaw || QuickView::IsRawExtension(e.t);
+        anyRendered = anyRendered || QuickView::IsRenderedPairExtension(e.t);
+        if (anyRaw && anyRendered) break;
+    }
+    if (!anyRaw || !anyRendered) return;
+
+    // Group pairing candidates by lowercase stem (file name minus extension;
+    // the scan covers a single directory, so the stem identifies the shot).
+    // Non-candidates (e.g. a same-name .png screenshot) neither pair nor
+    // block a pair.
+    struct Group {
+        int rawIdx = -1;
+        int renderedIdx = -1;
+        int rawCount = 0;
+        int renderedCount = 0;
+    };
+    std::unordered_map<std::wstring, Group> groups;
+    groups.reserve(entries.size());
+    for (int i = 0; i < (int)entries.size(); ++i) {
+        const auto& e = entries[i];
+        const bool isRaw = QuickView::IsRawExtension(e.t);
+        const bool isRendered = !isRaw && QuickView::IsRenderedPairExtension(e.t);
+        if (!isRaw && !isRendered) continue;
+
+        const size_t sep = e.p.find_last_of(L"\\/");
+        const size_t start = (sep == std::wstring::npos) ? 0 : sep + 1;
+        std::wstring stem = e.p.substr(start, e.p.size() - start - e.t.size());
+        std::transform(stem.begin(), stem.end(), stem.begin(), [](wchar_t c){ return std::towlower(c); });
+
+        Group& g = groups[stem];
+        if (isRaw) { g.rawCount++; g.rawIdx = i; }
+        else       { g.renderedCount++; g.renderedIdx = i; }
+    }
+
+    // Strict 1:1: fold only when a stem has exactly one RAW and exactly one
+    // rendered still. Ambiguous groups (rename collisions, bracketing
+    // leftovers) stay fully visible so the user can see and resolve them.
+    std::vector<char> hide(entries.size(), 0);
+    for (const auto& [stem, g] : groups) {
+        if (g.rawCount != 1 || g.renderedCount != 1) continue;
+        const SortEntry& raw = entries[g.rawIdx];
+        const SortEntry& rendered = entries[g.renderedIdx];
+        outPairedRaws.emplace(ComputePathHash(rendered.p),
+                              PairedRaw{ raw.p, raw.s, ComputePathHash(raw.p) });
+        hide[g.rawIdx] = 1;
+    }
+    if (outPairedRaws.empty()) return;
+
+    // Drop the hidden RAW entries, preserving sort order.
+    std::vector<SortEntry> kept;
+    kept.reserve(entries.size() - outPairedRaws.size());
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (!hide[i]) kept.push_back(std::move(entries[i]));
+    }
+    entries = std::move(kept);
 }
 
 void FileNavigator::SortEntries(std::vector<SortEntry>& entries, int sortOrder, bool sortDesc) {
@@ -687,6 +810,11 @@ FileNavigator::DirectoryScanResult FileNavigator::PerformDirectoryScan() {
     int sortOrder = g_runtime.SortOrder;
     bool sortDesc = g_runtime.SortDescending;
     SortEntries(entries, sortOrder, sortDesc);
+
+    // [RAW+JPEG Pairing] Same fold as Initialize (watcher rescan path)
+    if (g_config.PairRawJpeg) {
+        ApplyRawJpegPairing(entries, result.pairedRaws);
+    }
 
     result.files.clear();
     result.sizes.clear();

--- a/QuickView/FileNavigator.h
+++ b/QuickView/FileNavigator.h
@@ -107,6 +107,16 @@ public:
         return ComputePathHash(path);
     }
 
+    // [RAW+JPEG Pairing] "+CR3"-style label for a hidden RAW (its uppercase
+    // extension) — shared by the gallery badge, window title and info panel.
+    static std::wstring PairedRawLabel(const PairedRaw& raw) {
+        std::wstring_view ext = QuickView::ExtensionOf(raw.path);
+        if (!ext.empty()) ext.remove_prefix(1); // drop the dot
+        std::wstring label = L"+";
+        for (wchar_t c : ext) label += (wchar_t)std::towupper(c);
+        return label;
+    }
+
     // [RAW+JPEG Pairing] Query the RAW hidden behind a rendered file (by the
     // rendered file's ImageID); nullptr if that file has no hidden RAW.
     inline const PairedRaw* GetPairedRaw(ImageID renderedId) const {

--- a/QuickView/FileNavigator.h
+++ b/QuickView/FileNavigator.h
@@ -135,6 +135,12 @@ public:
     // [Directory Watcher] Apply pending scan result from background thread (main thread only)
     void ApplyPendingScanResult();
 
+    // [RAW+JPEG Pairing] Re-list the watched directory synchronously and apply
+    // the result (main thread only) -- used when the pairing setting toggles,
+    // so the open folder folds/unfolds without waiting for a watcher event.
+    // No-op for archives and when no folder is open.
+    void RescanDirectory();
+
     // Shared sort comparator for Entry vectors (used by Initialize and PerformDirectoryScan)
     struct SortEntry {
         std::wstring p;

--- a/QuickView/FileNavigator.h
+++ b/QuickView/FileNavigator.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <unordered_map>
 #include <filesystem>
 #include <algorithm>
 #include <cwctype>
@@ -30,11 +31,19 @@ inline ImageID ComputePathHash(const std::wstring& path) {
 
 class FileNavigator {
 public:
+    // [RAW+JPEG Pairing] A RAW hidden behind its same-name rendered sibling
+    struct PairedRaw {
+        std::wstring path;
+        uintmax_t size = 0;
+        ImageID id = 0;
+    };
+
     // Background scan result (produced by watcher thread, consumed by main thread)
     struct DirectoryScanResult {
         std::vector<std::wstring> files;
         std::vector<uintmax_t> sizes;
         std::vector<ImageID> ids;
+        std::unordered_map<ImageID, PairedRaw> pairedRaws;
     };
 
     FileNavigator() = default;
@@ -98,6 +107,18 @@ public:
         return ComputePathHash(path);
     }
 
+    // [RAW+JPEG Pairing] Query the RAW hidden behind a rendered file (by the
+    // rendered file's ImageID); nullptr if that file has no hidden RAW.
+    inline const PairedRaw* GetPairedRaw(ImageID renderedId) const {
+        auto it = m_pairedRaws.find(renderedId);
+        return it == m_pairedRaws.end() ? nullptr : &it->second;
+    }
+    inline bool HasPairedRaw(ImageID renderedId) const {
+        return m_pairedRaws.find(renderedId) != m_pairedRaws.end();
+    }
+    inline size_t PairedRawCount() const { return m_pairedRaws.size(); }
+
+
     // [Directory Watcher] Apply pending scan result from background thread (main thread only)
     void ApplyPendingScanResult();
 
@@ -111,6 +132,14 @@ public:
     };
 
     static void SortEntries(std::vector<SortEntry>& entries, int sortOrder, bool sortDesc);
+
+    // [RAW+JPEG Pairing] Fold same-name RAW + rendered pairs: strict 1:1 per
+    // stem (exactly one RAW and exactly one whitelisted rendered still), the
+    // RAW entry is removed and recorded in outPairedRaws keyed by the rendered
+    // file's ImageID. Shared by Initialize and PerformDirectoryScan; pure on
+    // its inputs so it is unit-testable.
+    static void ApplyRawJpegPairing(std::vector<SortEntry>& entries,
+                                    std::unordered_map<ImageID, PairedRaw>& outPairedRaws);
 
 private:
     static std::wstring_view GetPhysicalHostPath(std::wstring_view vfsPath);
@@ -127,6 +156,8 @@ private:
     std::vector<std::wstring> m_files;
     std::vector<uintmax_t> m_sizes;
     std::vector<ImageID> m_ids;  // [ImageID] Precomputed path hashes
+    // [RAW+JPEG Pairing] Hidden RAWs keyed by their rendered sibling's ImageID
+    std::unordered_map<ImageID, PairedRaw> m_pairedRaws;
     int m_currentIndex = -1;
     bool m_hitEnd = false;
     std::wstring m_crossFolderMessage;

--- a/QuickView/FileNavigator.h
+++ b/QuickView/FileNavigator.h
@@ -4,6 +4,9 @@
 #include <string_view>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
+#include <atomic>
+#include <thread>
 #include <filesystem>
 #include <algorithm>
 #include <cwctype>
@@ -47,7 +50,7 @@ public:
     };
 
     FileNavigator() = default;
-    ~FileNavigator() { StopDirectoryWatcher(); }
+    ~FileNavigator() { StopPairVerification(); StopDirectoryWatcher(); }
     FileNavigator(const FileNavigator&) = delete;
     FileNavigator& operator=(const FileNavigator&) = delete;
 
@@ -146,10 +149,32 @@ public:
     // [RAW+JPEG Pairing] Fold same-name RAW + rendered pairs: strict 1:1 per
     // stem (exactly one RAW and exactly one whitelisted rendered still), the
     // RAW entry is removed and recorded in outPairedRaws keyed by the rendered
-    // file's ImageID. Shared by Initialize and PerformDirectoryScan; pure on
-    // its inputs so it is unit-testable.
+    // file's ImageID. Pairs whose rendered ImageID is in skipRendered (capture
+    // times verified as mismatching) are left unfolded. Shared by Initialize
+    // and PerformDirectoryScan; pure on its inputs so it is unit-testable.
     static void ApplyRawJpegPairing(std::vector<SortEntry>& entries,
-                                    std::unordered_map<ImageID, PairedRaw>& outPairedRaws);
+                                    std::unordered_map<ImageID, PairedRaw>& outPairedRaws,
+                                    const std::unordered_set<ImageID>* skipRendered = nullptr);
+
+    // [RAW+JPEG Pairing] Parse an EXIF "YYYY:MM:DD HH:MM:SS" timestamp to a
+    // local-time epoch value (the same convention LibRaw uses); 0 = unparsable.
+    static int64_t ParseExifDateTime(const std::string& exifDateTime);
+
+    // STRICT verification: a pair holds only when both capture times were
+    // read successfully AND are exactly equal (one shutter actuation writes
+    // the identical DateTimeOriginal into both files). An unreadable side
+    // fails verification too -- a same-name file without a readable capture
+    // time is likely not the camera's rendered output of this shot.
+    static bool PairVerificationFails(int64_t rendered, int64_t raw) {
+        return rendered == 0 || raw == 0 || rendered != raw;
+    }
+
+    // [RAW+JPEG Pairing] Capture-time reader for everything easyexif (JPEG
+    // only) cannot parse: RAW via LibRaw, HEIF etc. via WIC. Injected at
+    // startup because the unit-test binary links FileNavigator without
+    // LibRaw/WIC. Returns 0 when unavailable.
+    using CaptureTimeFallbackReader = int64_t (*)(const wchar_t* path);
+    static void SetCaptureTimeFallbackReader(CaptureTimeFallbackReader reader) { s_captureTimeFallback = reader; }
 
 private:
     static std::wstring_view GetPhysicalHostPath(std::wstring_view vfsPath);
@@ -162,12 +187,29 @@ private:
     void StartDirectoryWatcher(const std::wstring& dirPath);
     void StopDirectoryWatcher();
 
+    // [RAW+JPEG Pairing] Asynchronous capture-time verification of the folded
+    // pairs. Confirmed mismatches go into m_verifyUnpaired and a rescan is
+    // handed to the main thread through the directory-watcher channel.
+    void StartPairVerification();
+    void StopPairVerification();
+
     // Data Members
     std::vector<std::wstring> m_files;
     std::vector<uintmax_t> m_sizes;
     std::vector<ImageID> m_ids;  // [ImageID] Precomputed path hashes
     // [RAW+JPEG Pairing] Hidden RAWs keyed by their rendered sibling's ImageID
     std::unordered_map<ImageID, PairedRaw> m_pairedRaws;
+
+    // [RAW+JPEG Pairing] Capture-time verification state. Sets are keyed by
+    // the rendered file's ImageID and guarded by m_verifyMutex; they belong to
+    // m_verifyDir and reset when the browsed folder changes.
+    std::thread m_verifyThread;
+    std::mutex m_verifyMutex;
+    std::unordered_set<ImageID> m_verifyDone;      // checked (match or mismatch)
+    std::unordered_set<ImageID> m_verifyUnpaired;  // confirmed mismatch: never fold
+    std::wstring m_verifyDir;
+    std::atomic<uint32_t> m_verifyGeneration{ 0 }; // cancels superseded runs
+    inline static CaptureTimeFallbackReader s_captureTimeFallback = nullptr;
     int m_currentIndex = -1;
     bool m_hitEnd = false;
     std::wstring m_crossFolderMessage;

--- a/QuickView/GalleryOverlay.cpp
+++ b/QuickView/GalleryOverlay.cpp
@@ -390,6 +390,7 @@ void GalleryOverlay::Render(ID2D1DeviceContext* pDC, const D2D1_SIZE_F& size, ID
         m_textFormat.Reset();
         m_textFormatStats.Reset();
         m_textFormatOSD.Reset();
+        m_textFormatBadge.Reset();
         lastScale = g_uiScale;
     }
     if (!m_dwriteFactory) {
@@ -399,6 +400,11 @@ void GalleryOverlay::Render(ID2D1DeviceContext* pDC, const D2D1_SIZE_F& size, ID
         m_dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr, DWRITE_FONT_WEIGHT_MEDIUM, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, 12.0f * g_uiScale, L"en-us", &m_textFormat);
         m_dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr, DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, 10.0f * g_uiScale, L"en-us", &m_textFormatStats);
         m_dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr, DWRITE_FONT_WEIGHT_BOLD, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, 20.0f * g_uiScale, L"en-us", &m_textFormatOSD);
+        m_dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr, DWRITE_FONT_WEIGHT_SEMI_BOLD, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, 9.0f * g_uiScale, L"en-us", &m_textFormatBadge);
+        if (m_textFormatBadge) {
+            m_textFormatBadge->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+            m_textFormatBadge->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+        }
     }
     
     size_t count = m_pNav->Count();
@@ -530,6 +536,27 @@ void GalleryOverlay::Render(ID2D1DeviceContext* pDC, const D2D1_SIZE_F& size, ID
                 m_pThumbMgr->QueueRequest(imgId, path.c_str(), prio);
             }
         }
+
+        // [RAW+JPEG Pairing] "+CR3"-style badge: this item carries a hidden
+        // RAW. Theme-independent dark chip so it reads on any photo content.
+        if (const FileNavigator::PairedRaw* pairedRaw = m_pNav->GetPairedRaw(imgId)) {
+            const std::wstring badgeText = FileNavigator::PairedRawLabel(*pairedRaw);
+            const float bw = (8.0f + 6.5f * (float)badgeText.length()) * g_uiScale;
+            const float bh = 15.0f * g_uiScale;
+            const float bm = 5.0f * g_uiScale;
+            const float br = 3.5f * g_uiScale;
+            D2D1_RECT_F badge = D2D1::RectF(cellRect.right - bm - bw, cellRect.top + bm, cellRect.right - bm, cellRect.top + bm + bh);
+            m_brushBg->SetColor(D2D1::ColorF(0.0f, 0.0f, 0.0f, 0.55f));
+            m_brushBg->SetOpacity(m_transitionProgress);
+            pDC->FillRoundedRectangle(D2D1::RoundedRect(badge, br, br), m_brushBg.Get());
+
+            D2D1_COLOR_F prevBadgeTxt = m_brushText->GetColor();
+            m_brushText->SetColor(D2D1::ColorF(D2D1::ColorF::White));
+            m_brushText->SetOpacity(m_transitionProgress * 0.95f);
+            pDC->DrawText(badgeText.c_str(), (UINT32)badgeText.length(), m_textFormatBadge.Get(), badge, m_brushText.Get());
+            m_brushText->SetColor(prevBadgeTxt);
+            m_brushText->SetOpacity(1.0f);
+        }
     }
     
     // 4. Hover Tooltip Rendering
@@ -561,6 +588,11 @@ void GalleryOverlay::Render(ID2D1DeviceContext* pDC, const D2D1_SIZE_F& size, ID
                 }
             } else {
                 swprintf_s(statsBuf, L"Loading...");
+            }
+            // [RAW+JPEG Pairing] Flag the hidden RAW in the hover stats
+            if (const FileNavigator::PairedRaw* pairedRaw = m_pNav->GetPairedRaw(imgId); pairedRaw && !info.isFailed) {
+                wcscat_s(statsBuf, L"  •  ");
+                wcscat_s(statsBuf, FileNavigator::PairedRawLabel(*pairedRaw).c_str());
             }
             
             D2D1_RECT_F tooltipRect = D2D1::RectF(cellRect.left + 8.0f * g_uiScale, cellRect.top + 8.0f * g_uiScale, cellRect.left + 8.0f * g_uiScale + tooltipW, cellRect.top + 8.0f * g_uiScale + tooltipH);

--- a/QuickView/GalleryOverlay.h
+++ b/QuickView/GalleryOverlay.h
@@ -173,6 +173,7 @@ private:
     ComPtr<IDWriteTextFormat> m_textFormat; // For Grid cells (Title)
     ComPtr<IDWriteTextFormat> m_textFormatStats; // For stats
     ComPtr<IDWriteTextFormat> m_textFormatOSD; // For global stats
+    ComPtr<IDWriteTextFormat> m_textFormatBadge; // For the "+RAW" pairing badge
 
     // GeekGlass Support
     QuickView::UI::GeekGlass::GeekGlassEngine m_geekGlass;

--- a/QuickView/ImageLoader.cpp
+++ b/QuickView/ImageLoader.cpp
@@ -10353,6 +10353,84 @@ static HRESULT GetMetadataGPS(IWICMetadataQueryReader *reader,
   return S_OK;
 }
 
+// [RAW+JPEG Pairing] Capture-time fallback reader for everything easyexif
+// (JPEG-only) cannot parse. Dispatches by classification: RAW via a LibRaw
+// metadata parse (open_file only, no unpack -- a few ms), anything else
+// (HEIF, XMP-only JPEG) via a WIC metadata-only query (the same query paths
+// PopulateExifFromQueryReader uses). Registered into FileNavigator at
+// startup; it lives here because the unit-test binary links FileNavigator
+// without LibRaw/WIC. Returns 0 when unavailable.
+int64_t ReadCaptureTimeFallback(const wchar_t *filePath) {
+  if (!filePath)
+    return 0;
+
+  if (QuickView::IsRawPath(filePath)) {
+    LibRaw RawProcessor;
+
+    std::string pathUtf8;
+    int len = WideCharToMultiByte(CP_UTF8, 0, filePath, -1, NULL, 0, NULL, NULL);
+    if (len <= 0)
+      return 0;
+    pathUtf8.resize(len);
+    WideCharToMultiByte(CP_UTF8, 0, filePath, -1, &pathUtf8[0], len, NULL, NULL);
+    pathUtf8.pop_back();
+
+    if (RawProcessor.open_file(pathUtf8.c_str()) != LIBRAW_SUCCESS)
+      return 0;
+    return (int64_t)RawProcessor.imgdata.other.timestamp;
+  }
+
+  // WIC metadata-only read. The verification thread owns no COM apartment,
+  // so initialize one locally; scope the COM objects so they release first.
+  const HRESULT coInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  int64_t result = 0;
+  {
+    ComPtr<IWICImagingFactory> factory;
+    ComPtr<IWICBitmapDecoder> decoder;
+    ComPtr<IWICBitmapFrameDecode> frame;
+    ComPtr<IWICMetadataQueryReader> reader;
+    if (SUCCEEDED(CoCreateInstance(CLSID_WICImagingFactory, nullptr,
+                                   CLSCTX_INPROC_SERVER,
+                                   IID_PPV_ARGS(&factory))) &&
+        SUCCEEDED(factory->CreateDecoderFromFilename(
+            filePath, nullptr, GENERIC_READ, WICDecodeMetadataCacheOnDemand,
+            &decoder)) &&
+        SUCCEEDED(decoder->GetFrame(0, &frame)) &&
+        SUCCEEDED(frame->GetMetadataQueryReader(&reader))) {
+      static const wchar_t *kDateQueries[] = {
+          L"/app1/ifd/exif/{ushort=36867}", L"/ifd/exif/{ushort=36867}",
+          L"/xmp/exif:DateTimeOriginal",    L"/app1/ifd/{ushort=306}",
+          L"/ifd/{ushort=306}",             L"/xmp/tiff:DateTime",
+          L"/xmp/xmp:CreateDate"};
+      for (const auto *query : kDateQueries) {
+        PROPVARIANT var;
+        PropVariantInit(&var);
+        if (FAILED(reader->GetMetadataByName(query, &var)))
+          continue;
+        std::string dateStr;
+        if (var.vt == VT_LPSTR && var.pszVal) {
+          dateStr = var.pszVal;
+        } else if ((var.vt == VT_LPWSTR && var.pwszVal) ||
+                   (var.vt == VT_BSTR && var.bstrVal)) {
+          // EXIF timestamps are ASCII digits/colons; narrow directly
+          const wchar_t *w = (var.vt == VT_LPWSTR) ? var.pwszVal : var.bstrVal;
+          for (; *w; ++w)
+            dateStr.push_back((char)(*w & 0x7F));
+        }
+        PropVariantClear(&var);
+        if (!dateStr.empty()) {
+          result = FileNavigator::ParseExifDateTime(dateStr);
+          if (result != 0)
+            break;
+        }
+      }
+    }
+  }
+  if (SUCCEEDED(coInit))
+    CoUninitialize();
+  return result;
+}
+
 // [v5.1] LibRaw Metadata Helper
 static HRESULT ReadMetadataLibRaw(LPCWSTR filePath,
                                   CImageLoader::ImageMetadata *pMetadata) {

--- a/QuickView/ImageLoader.cpp
+++ b/QuickView/ImageLoader.cpp
@@ -1365,30 +1365,14 @@ static std::wstring DetectFormatFromContent(LPCWSTR filePath) {
 
   // === STEP 1: Extension-based RAW Detection (Highest Priority) ===
   // This MUST run first. RAW formats cannot be reliably detected by magic
-  // bytes.
-  std::wstring pathLower = filePath;
-  std::transform(pathLower.begin(), pathLower.end(), pathLower.begin(),
-                 ::towlower);
+  // bytes. Classification list lives in SupportedExtensions.h.
+  // Note: .tif/.tiff excluded - standard TIFFs should use WIC, not LibRaw.
+  if (QuickView::IsRawPath(filePath))
+    return L"RAW"; // Definitive RAW identification by extension
 
-  // Comprehensive LibRaw Extension List (40+ formats) + SVG
-  static const wchar_t *rawExts[] = {
-      L".3fr", L".ari",  L".arw", L".bay", L".braw", L".cr2", L".cr3", L".crw",
-      L".cap", L".data", L".dcs", L".dcr", L".dng",  L".drf", L".eip", L".erf",
-      L".fff", L".gpr",  L".iiq", L".k25", L".kdc",  L".mdc", L".mef", L".mos",
-      L".mrw", L".nef",  L".nrw", L".obm", L".orf",  L".pef", L".ptx", L".pxn",
-      L".r3d", L".raf",  L".raw", L".rwl", L".rw2",  L".rwz", L".sr2", L".srf",
-      L".srw", L".sti",  L".x3f",
-      L".svg" // [v9.5] SVG detection
-      // Note: .tif/.tiff excluded - standard TIFFs should use WIC, not LibRaw
-  };
-
-  for (const auto *ext : rawExts) {
-    if (pathLower.ends_with(ext)) {
-      if (wcscmp(ext, L".svg") == 0)
-        return L"SVG"; // Special case for SVG
-      return L"RAW";   // Definitive RAW identification by extension
-    }
-  }
+  // [v9.5] SVG detection
+  if (QuickView::ExtEqualsIgnoreCase(QuickView::ExtensionOf(filePath), L".svg"))
+    return L"SVG";
 
   // === STEP 2: Magic Bytes Detection (for non-RAW formats) ===
   uint8_t magic[32] = {0};
@@ -1401,16 +1385,17 @@ static std::wstring DetectFormatFromContent(LPCWSTR filePath) {
   // === STEP 3: Extension Fallbacks (for problematic formats) ===
   // TGA: Some TGAs have no reliable magic signature
   if (fmt == L"Unknown") {
-    if (pathLower.ends_with(L".tga"))
+    const std::wstring_view ext = QuickView::ExtensionOf(filePath);
+    if (QuickView::ExtEqualsIgnoreCase(ext, L".tga"))
       return L"TGA";
-    if (pathLower.ends_with(L".jxl"))
+    if (QuickView::ExtEqualsIgnoreCase(ext, L".jxl"))
       return L"JXL";
-    if (pathLower.ends_with(L".dds"))
+    if (QuickView::ExtEqualsIgnoreCase(ext, L".dds"))
       return L"DDS";
-    if (pathLower.ends_with(L".wdp") || pathLower.ends_with(L".hdp") ||
-        pathLower.ends_with(L".jxr"))
+    if (QuickView::ExtEqualsIgnoreCase(ext, L".wdp") || QuickView::ExtEqualsIgnoreCase(ext, L".hdp") ||
+        QuickView::ExtEqualsIgnoreCase(ext, L".jxr"))
       return L"JXR";
-    if (pathLower.ends_with(L".hif"))
+    if (QuickView::ExtEqualsIgnoreCase(ext, L".hif"))
       return L"HEIC";
   }
 
@@ -5689,12 +5674,7 @@ HRESULT CImageLoader::LoadToMemory(LPCWSTR filePath, IWICBitmap **ppBitmap,
   // 2. Handle TIFF (CR2, NEF, ARW often identify as TIFF via Magic Bytes)
   else if (detectedFmt == L"TIFF") {
     // Check if it's actually a RAW file based on extension
-    if (path.ends_with(L".arw") || path.ends_with(L".cr2") ||
-        path.ends_with(L".nef") || path.ends_with(L".dng") ||
-        path.ends_with(L".orf") || path.ends_with(L".rw2") ||
-        path.ends_with(L".raf") || path.ends_with(L".pef") ||
-        path.ends_with(L".srw") || path.ends_with(L".cr3") ||
-        path.ends_with(L".nrw")) {
+    if (QuickView::IsRawPath(path)) {
       HRESULT hr = LoadRaw(filePath, ppBitmap, forceFullDecode);
       if (SUCCEEDED(hr)) {
         if (pLoaderName)
@@ -5709,12 +5689,7 @@ HRESULT CImageLoader::LoadToMemory(LPCWSTR filePath, IWICBitmap **ppBitmap,
   // RAW Check (no magic bytes usually reliable OR falls into Unknown)
   if (detectedFmt == L"Unknown") {
     // Check extension
-    if (path.ends_with(L".arw") || path.ends_with(L".cr2") ||
-        path.ends_with(L".nef") || path.ends_with(L".dng") ||
-        path.ends_with(L".orf") || path.ends_with(L".rw2") ||
-        path.ends_with(L".raf") || path.ends_with(L".pef") ||
-        path.ends_with(L".srw") || path.ends_with(L".cr3") ||
-        path.ends_with(L".nrw")) {
+    if (QuickView::IsRawPath(path)) {
       HRESULT hr = LoadRaw(filePath, ppBitmap, forceFullDecode);
       if (SUCCEEDED(hr)) {
         if (pLoaderName)
@@ -10890,19 +10865,9 @@ HRESULT CImageLoader::ReadMetadata(LPCWSTR filePath, ImageMetadata *pMetadata,
 
   // 2. Dispatch
   if (pMetadata->Format == L"Raw" || pMetadata->Format == L"Unknown") {
-    // Try LibRaw first for metadata
-    std::wstring path = filePath;
-    std::transform(path.begin(), path.end(), path.begin(), ::towlower);
-
-    bool isRawExt = (path.ends_with(L".arw") || path.ends_with(L".cr2") ||
-                     path.ends_with(L".nef") || path.ends_with(L".dng") ||
-                     path.ends_with(L".orf") || path.ends_with(L".rw2") ||
-                     path.ends_with(L".raf") || path.ends_with(L".pef") ||
-                     path.ends_with(L".srw") || path.ends_with(L".cr3") ||
-                     path.ends_with(L".nrw") || path.ends_with(L".heic") ||
-                     path.ends_with(L".heif") || path.ends_with(L".hif"));
-
-    if (isRawExt) {
+    // Try LibRaw first for metadata (RAW formats plus HEIF, whose embedded
+    // EXIF LibRaw also parses)
+    if (QuickView::IsRawPath(filePath) || QuickView::IsHeifPath(filePath)) {
       if (SUCCEEDED(ReadMetadataLibRaw(filePath, pMetadata))) {
         // LibRaw succeeded - metadata fields populated
         // Continue to WIC for GPS if needed (or other missing fields)

--- a/QuickView/SettingsOverlay.cpp
+++ b/QuickView/SettingsOverlay.cpp
@@ -1765,6 +1765,18 @@ void SettingsOverlay::BuildMenu() {
     itemRaw.onChange = []([[maybe_unused]] SettingsOverlay* overlay, [[maybe_unused]] SettingsItem* item) { g_runtime.ForceRawDecode = g_config.ForceRawDecode; };
     tabImage.items.push_back(itemRaw);
 
+    // [RAW+JPEG Pairing] Fold same-name RAW+JPEG shots into one photo
+    SettingsItem itemPairRaw = { AppStrings::Settings_Label_PairRawJpeg, OptionType::Toggle, &g_config.PairRawJpeg };
+    itemPairRaw.tooltipText = AppStrings::Settings_Tooltip_PairRawJpeg;
+    itemPairRaw.onChange = []([[maybe_unused]] SettingsOverlay* overlay, [[maybe_unused]] SettingsItem* item) {
+        extern void SaveConfig();
+        extern HWND g_mainHwnd;
+        extern void ApplyPairRawJpegSetting(HWND hwnd);
+        SaveConfig();
+        ApplyPairRawJpegSetting(g_mainHwnd);
+    };
+    tabImage.items.push_back(itemPairRaw);
+
     // --- 2. Color Management (CMS) Group ---
     tabImage.items.push_back({ AppStrings::Settings_Label_CMS, OptionType::Header });
 

--- a/QuickView/SupportedExtensions.h
+++ b/QuickView/SupportedExtensions.h
@@ -136,6 +136,33 @@ constexpr bool IsArchivePath(std::wstring_view path) {
     return IsArchiveExtension(ExtensionOf(path));
 }
 
+// ============================================================================
+// RAW+JPEG pairing policy
+// ============================================================================
+// The out-of-camera *rendered* stills that legitimately sit next to a RAW (the
+// visible half of a RAW+JPEG pair). Deliberately a curated WHITELIST of what
+// cameras actually write, NOT "everything that isn't RAW": no camera writes a
+// .png/.psd/.svg beside a RAW, so a same-name file of such a type comes from
+// some other software (an export, an edit, a generated file) and a RAW must
+// never be hidden behind it.
+// JPEG family: every camera writes .JPG; .JPEG appears via software.
+// HEIF family: Canon/Nikon/Sony/Fujifilm write .HIF to the card; Apple and
+// newer Panasonic use .HEIC; .HEIF covers generic/Hasselblad HEIF. Excluded on
+// purpose: TIFF (no modern camera captures it -- it only appears via in-camera
+// RAW development, so a same-name .tif is a RAW-derived export) and Panasonic
+// HLG .HSP (not in SUPPORTED_EXTENSIONS, so QuickView cannot display it).
+inline constexpr std::array<std::wstring_view, 5> RENDERED_PAIR_EXTENSIONS = {
+    L".jpg", L".jpeg", L".heic", L".heif", L".hif"
+};
+
+// Can this extension be the visible (rendered) half of a RAW+JPEG pair?
+constexpr bool IsRenderedPairExtension(std::wstring_view ext) {
+    for (const auto& r : RENDERED_PAIR_EXTENSIONS) {
+        if (ExtEqualsIgnoreCase(ext, r)) return true;
+    }
+    return false;
+}
+
 // Compile-time regression tests (zero runtime cost)
 static_assert(SUPPORTED_EXTENSIONS.size() == 67);
 static_assert(RAW_EXTENSIONS.size() == 43);
@@ -148,6 +175,9 @@ static_assert(!IsRawPath(L"C:\\dir.raw\\readme"));
 static_assert(ExtensionOf(L"C:\\a\\manga.cbz|12|page01.png") == L".png");
 static_assert(IsHeifExtension(L".HIF"));
 static_assert(IsArchivePath(L"C:\\comics\\manga.CBZ"));
+static_assert(IsRenderedPairExtension(L".JPG"));
+static_assert(!IsRenderedPairExtension(L".tif"));  // TIFF is a RAW-derived export
+static_assert(!IsRenderedPairExtension(L".png")); // not camera-written beside a RAW
 
 // Generate the COMDLG filter string, e.g., "All Images\0*.jpg;*.png...\0All Files\0*.*\0\0"
 inline std::wstring GetSupportedExtensionsFilter() {

--- a/QuickView/SupportedExtensions.h
+++ b/QuickView/SupportedExtensions.h
@@ -5,28 +5,156 @@
 
 namespace QuickView {
 
-inline constexpr std::wstring_view SUPPORTED_EXTENSIONS[] = {
-    // Standard
-    L".jpg", L".jpeg", L".jpe", L".jfif", L".png", L".bmp", L".dib", L".gif", 
-    L".tif", L".tiff", L".ico", 
-    // Web / Modern
-    L".webp", L".avif", L".avifs", L".heic", L".heif", L".svg", L".svgz", L".jxl", L".apng",
-    // Professional / HDR / Legacy
-    L".exr", L".hdr", L".pic", L".psd", L".psb", L".tga", L".icb", L".vda", L".vst", L".pcx", L".qoi", 
-    L".wbmp", L".pam", L".pbm", L".pgm", L".ppm", L".pnm", L".wdp", L".hdp", L".jxr", L".hif",
-    // RAW Formats (LibRaw supported)
+// ============================================================================
+// Extension lists — single source of truth
+// ============================================================================
+// Every extension appears in EXACTLY ONE segment below. The public lists
+// (SUPPORTED_EXTENSIONS, RAW_EXTENSIONS) are assembled from the segments at
+// compile time via consteval concatenation, so the segments can never drift
+// apart. All helpers are constexpr and allocation-free (zero-cost: they
+// compile down to the same comparisons the old hand-written checks did).
+// Extensions are ASCII by definition, so case folding is a constexpr A-Z map.
+
+namespace detail {
+
+template <std::size_t... Ns>
+consteval auto Concat(const std::array<std::wstring_view, Ns>&... lists) {
+    std::array<std::wstring_view, (Ns + ...)> result{};
+    std::size_t i = 0;
+    (([&] { for (const auto& e : lists) result[i++] = e; }()), ...);
+    return result;
+}
+
+// Standard raster formats
+inline constexpr std::array<std::wstring_view, 11> STANDARD_EXTENSIONS = {
+    L".jpg", L".jpeg", L".jpe", L".jfif", L".png", L".bmp", L".dib", L".gif",
+    L".tif", L".tiff", L".ico"
+};
+
+// Web / Modern formats
+inline constexpr std::array<std::wstring_view, 9> WEB_MODERN_EXTENSIONS = {
+    L".webp", L".avif", L".avifs", L".heic", L".heif", L".svg", L".svgz", L".jxl", L".apng"
+};
+
+// Professional / HDR / Legacy formats
+inline constexpr std::array<std::wstring_view, 21> PRO_LEGACY_EXTENSIONS = {
+    L".exr", L".hdr", L".pic", L".psd", L".psb", L".tga", L".icb", L".vda", L".vst", L".pcx", L".qoi",
+    L".wbmp", L".pam", L".pbm", L".pgm", L".ppm", L".pnm", L".wdp", L".hdp", L".jxr", L".hif"
+};
+
+// Camera RAW formats that QuickView browses (LibRaw-decoded, part of
+// SUPPORTED_EXTENSIONS)
+inline constexpr std::array<std::wstring_view, 22> CAMERA_RAW_EXTENSIONS = {
     L".arw", L".cr2", L".cr3", L".crw", L".dng", L".nef", L".orf", L".raf", L".rw2", L".srw", L".x3f",
-    L".mrw", L".mos", L".kdc", L".dcr", L".sr2", L".pef", L".erf", L".3fr", L".mef", L".nrw", L".raw",
-    // Archives (VFS supported)
+    L".mrw", L".mos", L".kdc", L".dcr", L".sr2", L".pef", L".erf", L".3fr", L".mef", L".nrw", L".raw"
+};
+
+// Additional RAW extensions recognized for classification/decode-routing but
+// not browsed in folder playlists (rare stills, digital-back and cine formats;
+// reachable via Open dialog "All Files", drag-drop or the command line)
+inline constexpr std::array<std::wstring_view, 21> EXTENDED_RAW_EXTENSIONS = {
+    L".ari", L".bay", L".braw", L".cap", L".data", L".dcs", L".drf", L".eip", L".fff", L".gpr",
+    L".iiq", L".k25", L".mdc", L".obm", L".ptx", L".pxn", L".r3d", L".rwl", L".rwz", L".srf", L".sti"
+};
+
+// Archive container formats browsed via the VFS
+inline constexpr std::array<std::wstring_view, 4> ARCHIVE_EXTENSIONS_SEG = {
     L".cbz", L".zip", L".cbr", L".rar"
 };
+
+} // namespace detail
+
+// Everything QuickView can open from a folder scan
+inline constexpr auto SUPPORTED_EXTENSIONS = detail::Concat(
+    detail::STANDARD_EXTENSIONS, detail::WEB_MODERN_EXTENSIONS, detail::PRO_LEGACY_EXTENSIONS,
+    detail::CAMERA_RAW_EXTENSIONS, detail::ARCHIVE_EXTENSIONS_SEG);
+
+// Every extension classified as camera RAW (decode-routing, RAW toggles, etc.)
+inline constexpr auto RAW_EXTENSIONS = detail::Concat(
+    detail::CAMERA_RAW_EXTENSIONS, detail::EXTENDED_RAW_EXTENSIONS);
+
+// Archive container formats (VFS)
+inline constexpr auto ARCHIVE_EXTENSIONS = detail::ARCHIVE_EXTENSIONS_SEG;
+
+// ============================================================================
+// Classification helpers (constexpr, allocation-free, case-insensitive)
+// ============================================================================
+
+constexpr wchar_t ToLowerAscii(wchar_t c) {
+    return (c >= L'A' && c <= L'Z') ? static_cast<wchar_t>(c + (L'a' - L'A')) : c;
+}
+
+// Case-insensitive compare; both sides are expected to include the dot.
+constexpr bool ExtEqualsIgnoreCase(std::wstring_view a, std::wstring_view b) {
+    if (a.size() != b.size()) return false;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (ToLowerAscii(a[i]) != ToLowerAscii(b[i])) return false;
+    }
+    return true;
+}
+
+// Extension of a plain or VFS path ("dir\a.CR3" -> ".CR3", "a.zip|0|b.png" ->
+// ".png"), empty if none. A dot inside a directory name does not count.
+constexpr std::wstring_view ExtensionOf(std::wstring_view path) {
+    const std::size_t dot = path.find_last_of(L'.');
+    if (dot == std::wstring_view::npos) return {};
+    const std::size_t sep = path.find_last_of(L"\\/|");
+    if (sep != std::wstring_view::npos && sep > dot) return {};
+    return path.substr(dot);
+}
+
+constexpr bool IsRawExtension(std::wstring_view ext) {
+    for (const auto& raw : RAW_EXTENSIONS) {
+        if (ExtEqualsIgnoreCase(ext, raw)) return true;
+    }
+    return false;
+}
+
+constexpr bool IsRawPath(std::wstring_view path) {
+    return IsRawExtension(ExtensionOf(path));
+}
+
+// HEIF family (camera .hif plus .heic/.heif); the extensions live in their
+// support segments above — this checks the family without a duplicate list.
+constexpr bool IsHeifExtension(std::wstring_view ext) {
+    return ExtEqualsIgnoreCase(ext, L".heic") || ExtEqualsIgnoreCase(ext, L".heif")
+        || ExtEqualsIgnoreCase(ext, L".hif");
+}
+
+constexpr bool IsHeifPath(std::wstring_view path) {
+    return IsHeifExtension(ExtensionOf(path));
+}
+
+constexpr bool IsArchiveExtension(std::wstring_view ext) {
+    for (const auto& a : ARCHIVE_EXTENSIONS) {
+        if (ExtEqualsIgnoreCase(ext, a)) return true;
+    }
+    return false;
+}
+
+constexpr bool IsArchivePath(std::wstring_view path) {
+    return IsArchiveExtension(ExtensionOf(path));
+}
+
+// Compile-time regression tests (zero runtime cost)
+static_assert(SUPPORTED_EXTENSIONS.size() == 67);
+static_assert(RAW_EXTENSIONS.size() == 43);
+static_assert(IsRawExtension(L".crw"));   // was missing from main.cpp's IsRawFile
+static_assert(IsRawExtension(L".CR3"));   // case-insensitive
+static_assert(!IsRawExtension(L".jpg"));
+static_assert(!IsRawExtension(L""));
+static_assert(IsRawPath(L"C:\\Photos\\IMG_0001.NEF"));
+static_assert(!IsRawPath(L"C:\\dir.raw\\readme"));
+static_assert(ExtensionOf(L"C:\\a\\manga.cbz|12|page01.png") == L".png");
+static_assert(IsHeifExtension(L".HIF"));
+static_assert(IsArchivePath(L"C:\\comics\\manga.CBZ"));
 
 // Generate the COMDLG filter string, e.g., "All Images\0*.jpg;*.png...\0All Files\0*.*\0\0"
 inline std::wstring GetSupportedExtensionsFilter() {
     std::wstring filter;
     filter.append(L"All Images");
     filter.push_back(L'\0');
-    
+
     for (size_t i = 0; i < std::size(SUPPORTED_EXTENSIONS); ++i) {
         filter += L"*";
         filter += SUPPORTED_EXTENSIONS[i];
@@ -34,14 +162,14 @@ inline std::wstring GetSupportedExtensionsFilter() {
             filter += L";";
         }
     }
-    
+
     filter.push_back(L'\0');
     filter.append(L"All Files");
     filter.push_back(L'\0');
     filter.append(L"*.*");
     filter.push_back(L'\0');
     filter.push_back(L'\0');
-    
+
     return filter;
 }
 

--- a/QuickView/ThumbnailManager.cpp
+++ b/QuickView/ThumbnailManager.cpp
@@ -297,21 +297,15 @@ void ThumbnailManager::QueueRequest(size_t imageId, LPCWSTR path, int priority) 
     }
 
     // Detect format for Lane Selection
-    std::wstring ext = path;
-    size_t dot = ext.find_last_of(L'.');
-    bool isFast = false;
-    if (dot != std::wstring::npos) {
-        std::wstring e = ext.substr(dot);
-        std::transform(e.begin(), e.end(), e.begin(), ::towlower);
-        // Fast Lane: JPEG (Optimized) + RAW/HEIC/PSD (Embedded Preview) + WebP (Scaled)
-        if (e == L".jpg" || e == L".jpeg" || e == L".jpe" || e == L".jfif" ||
-            e == L".arw" || e == L".cr2" || e == L".nef" || e == L".dng" || e == L".orf" || e == L".rw2" || e == L".raf" ||
-            e == L".heic" || e == L".heif" || e == L".hif" || e == L".avif" ||
-            e == L".psd" || e == L".psb" ||
-            e == L".webp") { 
-            isFast = true;
-        }
-    }
+    // Fast Lane: JPEG (Optimized) + RAW/HEIC/PSD (Embedded Preview) + WebP (Scaled)
+    const std::wstring_view e = QuickView::ExtensionOf(path);
+    const bool isFast =
+        QuickView::ExtEqualsIgnoreCase(e, L".jpg") || QuickView::ExtEqualsIgnoreCase(e, L".jpeg") ||
+        QuickView::ExtEqualsIgnoreCase(e, L".jpe") || QuickView::ExtEqualsIgnoreCase(e, L".jfif") ||
+        QuickView::IsRawExtension(e) || QuickView::IsHeifExtension(e) ||
+        QuickView::ExtEqualsIgnoreCase(e, L".avif") ||
+        QuickView::ExtEqualsIgnoreCase(e, L".psd") || QuickView::ExtEqualsIgnoreCase(e, L".psb") ||
+        QuickView::ExtEqualsIgnoreCase(e, L".webp");
     t.isFastLane = isFast;
 
     if (isFast) {

--- a/QuickView/Toolbar.cpp
+++ b/QuickView/Toolbar.cpp
@@ -502,6 +502,11 @@ const wchar_t *GetTooltipText(const ToolbarButton &btn) {
   case ToolbarButtonID::Exif:
     return AppStrings::Toolbar_Tooltip_Info;
   case ToolbarButtonID::RawToggle:
+    // [RAW+JPEG Pairing] On a paired item the button switches the displayed
+    // file rather than the decode quality
+    if (btn.isPaired)
+      return btn.isToggled ? AppStrings::Toolbar_Tooltip_RawPairBack
+                           : AppStrings::Toolbar_Tooltip_RawPairView;
     return btn.isToggled ? AppStrings::Toolbar_Tooltip_RawFull
                          : AppStrings::Toolbar_Tooltip_RawPreview;
   case ToolbarButtonID::CompareRawToggle:
@@ -1123,8 +1128,8 @@ void Toolbar::SetExifState(bool open) {
   for (auto &btn : m_buttons) { if (btn.id == ToolbarButtonID::Exif) { btn.isToggled = open; } }
 }
 
-void Toolbar::SetRawState(bool isRaw, bool isFullDecode) {
-  for (auto &btn : m_buttons) { if (btn.id == ToolbarButtonID::RawToggle) { btn.isEnabled = isRaw; if (isRaw) { btn.isToggled = isFullDecode; } } }
+void Toolbar::SetRawState(bool isRaw, bool isFullDecode, bool isPaired) {
+  for (auto &btn : m_buttons) { if (btn.id == ToolbarButtonID::RawToggle) { btn.isEnabled = isRaw; btn.isPaired = isRaw && isPaired; if (isRaw) { btn.isToggled = isFullDecode; } } }
 }
 
 void Toolbar::SetExtensionWarning(bool hasMismatch) {

--- a/QuickView/Toolbar.h
+++ b/QuickView/Toolbar.h
@@ -53,6 +53,7 @@ struct ToolbarButton {
     bool isToggled = false; // For Lock/Exif/Raw
     bool isWarning = false; // For FixExtension
     bool isHovered = false;
+    bool isPaired = false;  // [RAW+JPEG Pairing] RawToggle switches a pair
 };
 
 // Responsive hide: a group of buttons hidden together at the same priority level
@@ -92,7 +93,7 @@ public:
     // State Setters
     void SetLockState(bool locked);
     void SetExifState(bool open);
-    void SetRawState(bool isRaw, bool isFullDecode);
+    void SetRawState(bool isRaw, bool isFullDecode, bool isPaired = false);
     void SetExtensionWarning(bool hasMismatch);
     void SetGamutWarningAvailable(bool available);
     void SetGamutWarningActive(bool active);

--- a/QuickView/UIRenderer.cpp
+++ b/QuickView/UIRenderer.cpp
@@ -2266,6 +2266,22 @@ std::vector<InfoRow> UIRenderer::BuildGridRows(const CImageLoader::ImageMetadata
             swprintf_s(rawSizeBuf, L"%.2f KB", pairedRaw->size / 1024.0);
         }
         rows.push_back({L"\U0001F517", L"RAW", rawName, rawSizeBuf, rawName, TruncateMode::MiddleEllipsis, false});
+    } else if (std::wstring rendered = g_navigator.GetResolvedPath(imagePath); rendered != imagePath) {
+        // Viewing the RAW side of a pair: point back at the rendered sibling.
+        // Label = its concrete format (JPG/HEIC...), value = its file name.
+        std::wstring rname = rendered.substr(rendered.find_last_of(L"\\/") + 1);
+        std::wstring rlabel;
+        std::wstring_view rext = QuickView::ExtensionOf(rendered);
+        if (!rext.empty()) rext.remove_prefix(1);
+        for (wchar_t c : rext) rlabel += (wchar_t)std::towupper(c);
+        const int ridx = g_navigator.FindIndex(rendered);
+        wchar_t rSizeBuf[32] = L"";
+        if (const uintmax_t rsize = g_navigator.GetFileSize(ridx); rsize >= 1024 * 1024) {
+            swprintf_s(rSizeBuf, L"%.2f MB", rsize / (1024.0 * 1024.0));
+        } else if (g_navigator.GetFileSize(ridx) > 0) {
+            swprintf_s(rSizeBuf, L"%.2f KB", g_navigator.GetFileSize(ridx) / 1024.0);
+        }
+        rows.push_back({L"\U0001F517", rlabel.empty() ? L"Pair" : rlabel, rname, rSizeBuf, rname, TruncateMode::MiddleEllipsis, false});
     }
 
     // Row 2: Dimensions + Megapixels + Zoom

--- a/QuickView/UIRenderer.cpp
+++ b/QuickView/UIRenderer.cpp
@@ -2174,6 +2174,10 @@ D2D1_SIZE_F UIRenderer::GetRequiredInfoPanelSize() const {
         return D2D1::SizeF(16.0f * s + width + 32.0f * s + 152.0f * s, 32.0f * s + height + 32.0f * s);
     } else if (g_runtime.ShowInfoPanel && !g_runtime.InfoPanelExpanded) {
         std::wstring info = g_imagePath.substr(g_imagePath.find_last_of(L"\\/") + 1);
+        // [RAW+JPEG Pairing] Must match the draw path so the measured width fits
+        if (const auto* pairedRaw = g_navigator.GetPairedRaw(FileNavigator::PathToImageID(g_imagePath))) {
+            info += L" (" + FileNavigator::PairedRawLabel(*pairedRaw) + L")";
+        }
         if (g_currentMetadata.Width > 0) {
             wchar_t sz[64]; swprintf_s(sz, L"   %u x %u", g_currentMetadata.Width, g_currentMetadata.Height);
             info += sz;
@@ -2249,6 +2253,20 @@ std::vector<InfoRow> UIRenderer::BuildGridRows(const CImageLoader::ImageMetadata
     // Row 1: Filename
     std::wstring filename = imagePath.substr(imagePath.find_last_of(L"\\/") + 1);
     rows.push_back({L"\U0001F4C4", L"File", filename, L"", filename, TruncateMode::MiddleEllipsis, true});
+
+    // [RAW+JPEG Pairing] Hidden RAW sibling of this photo. Icon: link
+    // (U+1F517) = "file paired with this photo"; the film-frames icon is
+    // already taken by the Format row.
+    if (const auto* pairedRaw = g_navigator.GetPairedRaw(FileNavigator::PathToImageID(imagePath))) {
+        std::wstring rawName = pairedRaw->path.substr(pairedRaw->path.find_last_of(L"\\/") + 1);
+        wchar_t rawSizeBuf[32] = L"";
+        if (pairedRaw->size >= 1024 * 1024) {
+            swprintf_s(rawSizeBuf, L"%.2f MB", pairedRaw->size / (1024.0 * 1024.0));
+        } else if (pairedRaw->size > 0) {
+            swprintf_s(rawSizeBuf, L"%.2f KB", pairedRaw->size / 1024.0);
+        }
+        rows.push_back({L"\U0001F517", L"RAW", rawName, rawSizeBuf, rawName, TruncateMode::MiddleEllipsis, false});
+    }
 
     // Row 2: Dimensions + Megapixels + Zoom
     if (metadata.Width > 0) {
@@ -3055,6 +3073,11 @@ void UIRenderer::DrawCompactInfo(ID2D1DeviceContext* dc) {
         info = frameBuf;
     } else {
         info = g_imagePath.substr(g_imagePath.find_last_of(L"\\/") + 1);
+
+        // [RAW+JPEG Pairing] Flag the hidden RAW, e.g. "IMG_001.JPG (+CR3)"
+        if (const auto* pairedRaw = g_navigator.GetPairedRaw(FileNavigator::PathToImageID(g_imagePath))) {
+            info += L" (" + FileNavigator::PairedRawLabel(*pairedRaw) + L")";
+        }
 
         // Add Comic Page Info if in Archive
         if (g_navigator.GetArchive() != nullptr) {

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -310,6 +310,7 @@ std::array<HotkeyBinding, static_cast<size_t>(HotkeyAction::Count)> g_hotkeys = 
     HotkeyBinding{ HotkeyAction::ToggleFullscreen, KeyCombo{ VK_F11, 0 }, KeyCombo{ VK_F11, 0 } },
     HotkeyBinding{ HotkeyAction::ToggleSpan, KeyCombo{ VK_F11, 1 }, KeyCombo{ VK_F11, 1 } }, // Ctrl + F11
     HotkeyBinding{ HotkeyAction::ToggleSlideshow, KeyCombo{ VK_F10, 0 }, KeyCombo{ VK_F10, 0 } },
+    HotkeyBinding{ HotkeyAction::RenderRaw, KeyCombo{ 'D', 0 }, KeyCombo{ 'D', 0 } }, // Decode RAW / switch to paired RAW
     HotkeyBinding{ HotkeyAction::OpenFile, KeyCombo{ 'O', 0 }, KeyCombo{ 'O', 0 } },
     HotkeyBinding{ HotkeyAction::EditFile, KeyCombo{ 'E', 0 }, KeyCombo{ 'E', 0 } },
     HotkeyBinding{ HotkeyAction::RenameFile, KeyCombo{ VK_F2, 0 }, KeyCombo{ VK_F2, 0 } },
@@ -329,6 +330,14 @@ std::array<HotkeyBinding, static_cast<size_t>(HotkeyAction::Count)> g_hotkeys = 
 };
 RuntimeConfig g_runtime;
 SlideshowState g_slideshowState;
+
+// [RAW+JPEG Pairing] The pair currently being viewed through the RAW switch
+// (IDM_RENDER_RAW on a paired item). Tracked explicitly so switching back to
+// the rendered file works even if a rescan unfolds the pair meanwhile, and so
+// the load pipeline treats the switch as "same photo" (temporary state such
+// as ForceRawDecode survives). Cleared when navigating anywhere else.
+static std::wstring g_pairViewRawPath;
+static std::wstring g_pairViewRenderedPath;
 bool HandleHotkeyAction(HWND hwnd, HotkeyAction action);
 bool g_preserveViewStateOnNextLoad = false;
 
@@ -9015,6 +9024,10 @@ SKIP_EDGE_NAV:;
         if (hasImage && !targetPath.empty()) {
              extensionFixNeeded = CheckExtensionMismatch(targetPath, targetFmt);
              isRaw = QuickView::IsRawPath(targetPath);
+             // [RAW+JPEG Pairing] "Render RAW" also switches a paired item
+             if (!isRaw && !IsCompareModeActive()) {
+                 isRaw = GetPaneContext(PaneSlot::Primary).navigator.HasPairedRaw(FileNavigator::PathToImageID(targetPath));
+             }
         }
         
         bool isPixelArtMode = GetCurrentPixelArtState(hwnd);
@@ -9686,6 +9699,47 @@ SKIP_EDGE_NAV:;
         case IDM_FLIP_V:     PerformTransform(hwnd, TransformType::FlipVertical); break;
 
         case IDM_RENDER_RAW: {
+             // [RAW+JPEG Pairing] For a paired item in single view this action
+             // switches the DISPLAYED FILE: rendered JPG <-> hidden RAW (full
+             // decode -- the RAW's embedded preview is essentially the JPG).
+             if (!contextLeft && !IsCompareModeActive() && !contextPath.empty()) {
+                 const auto& nav = GetPaneContext(PaneSlot::Primary).navigator;
+                 const FileNavigator::PairedRaw* pairedRaw = nav.GetPairedRaw(FileNavigator::PathToImageID(contextPath));
+                 std::wstring renderedBack;
+                 if (!pairedRaw) {
+                     if (!g_pairViewRawPath.empty() && contextPath == g_pairViewRawPath) {
+                         // Currently viewing the RAW side (tracked state: robust
+                         // even if a rescan unfolded the pair meanwhile)
+                         renderedBack = g_pairViewRenderedPath;
+                     } else {
+                         std::wstring r = nav.GetResolvedPath(contextPath);
+                         if (r != contextPath) renderedBack = std::move(r);
+                     }
+                 }
+                 if (pairedRaw || !renderedBack.empty()) {
+                     const bool toRaw = (pairedRaw != nullptr);
+                     // Remember the pair BEFORE loading: the load pipeline uses
+                     // this to treat the switch as "same photo" (preserves
+                     // ForceRawDecode and other temporary state)
+                     g_pairViewRawPath = toRaw ? pairedRaw->path : contextPath;
+                     g_pairViewRenderedPath = toRaw ? contextPath : renderedBack;
+
+                     g_runtime.ForceRawDecode = toRaw;
+                     g_toolbar.SetRawState(true, toRaw, true);
+                     if (g_imageEngine) {
+                         g_imageEngine->UpdateConfig(g_runtime);
+                         g_imageEngine->SetForceRefresh(true);
+                     }
+                     g_preservedViewState = GetPaneContext(PaneSlot::Primary).view;
+                     g_preserveViewStateOnNextLoad = true;
+                     ReleaseImageResources();
+                     LoadImageAsync(hwnd, toRaw ? g_pairViewRawPath.c_str() : g_pairViewRenderedPath.c_str());
+                     g_osd.Show(hwnd, toRaw ? L"Paired RAW (Full Decode)" : L"Paired Rendered Image", false);
+                     RequestRepaint(PaintLayer::All);
+                     break;
+                 }
+             }
+
              // [Fix] Toggle Force RAW Decode based on the selected pane's ACTUAL decode state.
              // This prevents "double click required" bugs when switching panes with mismatched states.
              bool isFullDecode = contextLeft ? GetPaneContext(PaneSlot::Left).metadata.IsRawFullDecode : GetPaneContext(PaneSlot::Primary).metadata.IsRawFullDecode;
@@ -11256,7 +11310,16 @@ void StartNavigation(HWND hwnd, std::wstring path, [[maybe_unused]] bool showOSD
     
     // [Fix] Only reset Runtime State if loading a NEW file.
     // If reloading the same file (e.g. RAW Toggle), preserve g_runtime.ForceRawDecode.
-    if (GetPaneContext(PaneSlot::Primary).path != path) {
+    // [RAW+JPEG Pairing] Switching between the two files of one pair is the
+    // same photo, not a new file -- temporary state survives the switch.
+    const bool pairViewSwitch = !g_pairViewRawPath.empty() &&
+        (path == g_pairViewRawPath || path == g_pairViewRenderedPath);
+    if (!pairViewSwitch && !g_pairViewRawPath.empty() &&
+        GetPaneContext(PaneSlot::Primary).path != path) {
+        g_pairViewRawPath.clear();
+        g_pairViewRenderedPath.clear();
+    }
+    if (GetPaneContext(PaneSlot::Primary).path != path && !pairViewSwitch) {
         g_runtime.ForceRawDecode = g_config.ForceRawDecode;
         
         // [Fix] Reverted to preserve manual LockWindowSize during navigation.
@@ -11337,7 +11400,14 @@ void StartNavigation(HWND hwnd, std::wstring path, [[maybe_unused]] bool showOSD
     
     // Update Toolbar State for RAW
     // [Fix] Ensure RAW button visibility is updated immediately on navigation
-    g_toolbar.SetRawState(QuickView::IsRawPath(path), g_runtime.ForceRawDecode);
+    // [RAW+JPEG Pairing] The button also switches a paired item to its RAW
+    {
+        const bool navHasPairedRaw = GetPaneContext(PaneSlot::Primary).navigator.HasPairedRaw(FileNavigator::PathToImageID(path));
+        const bool isPairedView = navHasPairedRaw
+            || (!g_pairViewRawPath.empty() && path == g_pairViewRawPath);
+        g_toolbar.SetRawState(QuickView::IsRawPath(path) || navHasPairedRaw,
+                              g_runtime.ForceRawDecode, isPairedView);
+    }
     if (IsCompareModeActive()) {
         RefreshCompareRawUI(hwnd);
     }
@@ -12595,6 +12665,26 @@ bool HandleHotkeyAction(HWND hwnd, HotkeyAction action) {
 
     case HotkeyAction::FlipV:
         PerformTransform(hwnd, TransformType::FlipVertical);
+        return true;
+
+    case HotkeyAction::RenderRaw:
+        if (IsCompareModeActive()) {
+            // Same routing as the compare toolbar RAW button
+            bool selIsRaw = false, selFull = false;
+            if (AppContext::GetInstance().CompareCtrl->GetPaneRawState(AppContext::GetInstance().Compare.selectedPane, selIsRaw, selFull) && selIsRaw) {
+                AppContext::GetInstance().Compare.contextPane = AppContext::GetInstance().Compare.selectedPane;
+                SendMessage(hwnd, WM_COMMAND, IDM_RENDER_RAW, 0);
+                RefreshCompareRawUI(hwnd);
+            }
+        } else {
+            const std::wstring& curPath = GetPaneContext(PaneSlot::Primary).path;
+            const bool applicable = !curPath.empty() &&
+                (QuickView::IsRawPath(curPath)
+                 || GetPaneContext(PaneSlot::Primary).navigator.HasPairedRaw(FileNavigator::PathToImageID(curPath)));
+            if (applicable) {
+                SendMessage(hwnd, WM_COMMAND, IDM_RENDER_RAW, 0);
+            }
+        }
         return true;
 
     case HotkeyAction::ToggleAnimation:

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -318,6 +318,7 @@ std::array<HotkeyBinding, static_cast<size_t>(HotkeyAction::Count)> g_hotkeys = 
     HotkeyBinding{ HotkeyAction::CopyImage, KeyCombo{ 'C', 1 }, KeyCombo{ 'C', 1 } }, // Ctrl + C
     HotkeyBinding{ HotkeyAction::CopyPath, KeyCombo{ 'C', 5 }, KeyCombo{ 'C', 5 } },  // Ctrl + Alt + C (1 | 4 = 5)
     HotkeyBinding{ HotkeyAction::ToggleCompare, KeyCombo{ 'C', 0 }, KeyCombo{ 'C', 0 } },
+    HotkeyBinding{ HotkeyAction::ComparePair, KeyCombo{ 'C', 2 }, KeyCombo{ 'C', 2 } }, // Shift + C: rendered vs RAW
     HotkeyBinding{ HotkeyAction::AlwaysOnTop, KeyCombo{ 'T', 1 }, KeyCombo{ 'T', 1 } }, // Ctrl + T
     HotkeyBinding{ HotkeyAction::ToggleDebugHud, KeyCombo{ VK_F12, 0 }, KeyCombo{ VK_F12, 0 } },
     HotkeyBinding{ HotkeyAction::Print, KeyCombo{ 'P', 1 }, KeyCombo{ 'P', 1 } }, // Ctrl + P
@@ -338,6 +339,12 @@ SlideshowState g_slideshowState;
 // as ForceRawDecode survives). Cleared when navigating anywhere else.
 static std::wstring g_pairViewRawPath;
 static std::wstring g_pairViewRenderedPath;
+// [RAW+JPEG Pairing] True while a pair-compare session (Shift+C) is active;
+// exiting compare then returns to the pair's rendered face.
+static bool g_pairCompareSession = false;
+static void ReturnToPairFaceAfterCompareExit(HWND hwnd);
+static void ArmPairRawFullDecode(const std::wstring& renderedPath, const std::wstring& rawPath);
+
 bool HandleHotkeyAction(HWND hwnd, HotkeyAction action);
 bool g_preserveViewStateOnNextLoad = false;
 
@@ -8279,6 +8286,7 @@ SKIP_EDGE_NAV:;
                 case ToolbarButtonID::CompareToggle:
                     if (IsCompareModeActive()) {
                         AppContext::GetInstance().CompareCtrl->ExitMode(hwnd);
+                        ReturnToPairFaceAfterCompareExit(hwnd);
                     } else {
                         AppContext::GetInstance().CompareCtrl->EnterMode(hwnd);
                     }
@@ -8292,6 +8300,7 @@ SKIP_EDGE_NAV:;
                     break;
                 case ToolbarButtonID::CompareExit:
                     AppContext::GetInstance().CompareCtrl->ExitMode(hwnd);
+                    ReturnToPairFaceAfterCompareExit(hwnd);
                     RequestRepaint(PaintLayer::All);
                     break;
                 case ToolbarButtonID::OverlayAlphaUp:
@@ -9627,6 +9636,7 @@ SKIP_EDGE_NAV:;
         case IDM_COMPARE_MODE: {
             if (IsCompareModeActive()) {
                 AppContext::GetInstance().CompareCtrl->ExitMode(hwnd);
+                ReturnToPairFaceAfterCompareExit(hwnd);
             } else {
                 AppContext::GetInstance().CompareCtrl->EnterMode(hwnd);
             }
@@ -9728,7 +9738,9 @@ SKIP_EDGE_NAV:;
                      g_toolbar.SetRawState(true, toRaw, true);
                      if (g_imageEngine) {
                          g_imageEngine->UpdateConfig(g_runtime);
-                         g_imageEngine->SetForceRefresh(true);
+                         // No SetForceRefresh: the two sides are different
+                         // files, and the engine's RAW quality check decides
+                         // between a cached frame and a re-decode.
                      }
                      g_preservedViewState = GetPaneContext(PaneSlot::Primary).view;
                      g_preserveViewStateOnNextLoad = true;
@@ -10176,18 +10188,24 @@ void ProcessEngineEvents(HWND hwnd) {
             if (evt.imageId != currentId) {
                 wchar_t idLog[128];
                 swprintf_s(idLog, L"[Main] ID Mismatch: Evt=%llu Cur=%llu\n", evt.imageId, currentId);
-                break; 
+                break;
             }
 
             bool isPreview = (evt.type == EventType::PreviewReady);
-            
-            // [Texture Promotion] 
+
+            // [Texture Promotion]
             // - If we are at Level 2 (Full), ignore Level 1 (Preview).
             if (g_imageQualityLevel >= 2 && isPreview) break;
 
+            // [Fix] A genuine RAW full decode may replace a resident frame
+            // that is not one (e.g. an embedded preview applied as final
+            // before a pending full decode completes) -- it is always an
+            // upgrade for the same image.
+            const bool rawFullUpgrade = evt.metadata.IsRawFullDecode &&
+                !GetPaneContext(PaneSlot::Primary).metadata.IsRawFullDecode;
 
             // - If we are at Level 2 (Full), ignore another Level 2 (no upgrade path).
-            if (g_imageQualityLevel >= 2 && !isPreview) break;
+            if (g_imageQualityLevel >= 2 && !isPreview && !rawFullUpgrade) break;
 
             ComPtr<ID2D1Bitmap> bitmap;
             HRESULT hr = E_FAIL;
@@ -10288,6 +10306,7 @@ void ProcessEngineEvents(HWND hwnd) {
                 g_isBlurry = isPreview;
                 g_imageQualityLevel = isPreview ? 1 : 2;
                 GetPaneContext(PaneSlot::Primary).path = evt.filePath;
+
                 
                 // Metadata
                 // [v5.4 Fix] Race Condition: Prevent FullReady (Basic) from overwriting Async EXIF
@@ -11311,10 +11330,16 @@ void StartNavigation(HWND hwnd, std::wstring path, [[maybe_unused]] bool showOSD
     // [Fix] Only reset Runtime State if loading a NEW file.
     // If reloading the same file (e.g. RAW Toggle), preserve g_runtime.ForceRawDecode.
     // [RAW+JPEG Pairing] Switching between the two files of one pair is the
-    // same photo, not a new file -- temporary state survives the switch.
+    // same photo, not a new file -- and the RAW side always renders at full
+    // decode. The flag is set HERE, by the pair file's own navigation (the
+    // last one to run before dispatch), so loads interleaved by message
+    // pumping cannot strip it before the decode worker reads it.
     const bool pairViewSwitch = !g_pairViewRawPath.empty() &&
         (path == g_pairViewRawPath || path == g_pairViewRenderedPath);
-    if (!pairViewSwitch && !g_pairViewRawPath.empty() &&
+    if (pairViewSwitch) {
+        g_runtime.ForceRawDecode = (path == g_pairViewRawPath);
+        if (g_imageEngine) g_imageEngine->UpdateConfig(g_runtime);
+    } else if (!g_pairViewRawPath.empty() &&
         GetPaneContext(PaneSlot::Primary).path != path) {
         g_pairViewRawPath.clear();
         g_pairViewRenderedPath.clear();
@@ -11660,6 +11685,53 @@ void NavigateEdge(HWND hwnd, bool toLast) {
 void Navigate(HWND hwnd, int direction) {
     if (GetPaneContext(PaneSlot::Primary).navigator.Count() <= 0) return;
     if (!CheckUnsavedChanges(hwnd)) return;
+
+    // [RAW+JPEG Pairing] Pair-compare session: the arrows move BOTH panes to
+    // the neighboring paired photo (left = rendered, right = RAW at full
+    // decode), regardless of pane focus. Items without a pair are skipped.
+    if (IsCompareModeActive() && g_pairCompareSession) {
+        auto& nav = GetPaneContext(PaneSlot::Primary).navigator;
+        const int count = (int)nav.Count();
+        int cur = nav.FindIndex(g_pairViewRenderedPath);
+        if (cur < 0) cur = nav.Index();
+
+        int idx = cur;
+        const FileNavigator::PairedRaw* nextRaw = nullptr;
+        for (int step = 0; step < count; ++step) {
+            idx += direction;
+            if (idx < 0 || idx >= count) {
+                if (!g_runtime.NavLoop) break;
+                idx = (idx < 0) ? count - 1 : 0;
+            }
+            if (idx == cur) break; // came full circle: no other paired photo
+            if (const FileNavigator::PairedRaw* pr = nav.GetPairedRaw(nav.GetImageID(idx))) {
+                nextRaw = pr;
+                break;
+            }
+        }
+        if (!nextRaw) {
+            g_osd.Show(hwnd, std::wstring(direction > 0 ? AppStrings::OSD_LastImage : AppStrings::OSD_FirstImage), false);
+            return;
+        }
+
+        const std::wstring rendered = nav.GetFile(idx);
+        const std::wstring raw = nextRaw->path;
+        nav.SetIndex(idx);
+        GetPaneContext(PaneSlot::Primary).editState.Reset();
+        if (!g_preserveViewStateOnNextLoad) {
+            GetPaneContext(PaneSlot::Primary).view.Reset();
+        }
+
+        ArmPairRawFullDecode(rendered, raw);
+        AppContext::GetInstance().CompareCtrl->LoadImageIntoLeftSlot(hwnd, rendered, [hwnd, raw](bool success) {
+            if (success) {
+                MarkCompareDirty();
+            }
+            LoadImageAsync(hwnd, raw.c_str());
+            RequestRepaint(PaintLayer::Image | PaintLayer::Static);
+        });
+        return;
+    }
 
     if (IsCompareModeActive() && g_toolbar.IsComicMode()) {
         int currentIndex = GetPaneContext(PaneSlot::Primary).navigator.Index();
@@ -12530,6 +12602,92 @@ void PerformAnimSeek(HWND hwnd, float targetProgress) {
     g_asyncSeekCV.notify_one();
 }
 
+// [RAW+JPEG Pairing] Enter compare mode with the two files of one pair side
+// by side: rendered image on the left, RAW (full decode) on the right.
+// [RAW+JPEG Pairing] Track the given pair and force full decode for its RAW
+// side: the pair's own navigation (StartNavigation) re-asserts the flag, so
+// interleaved loads cannot strip it before the decode worker reads it.
+static void ArmPairRawFullDecode(const std::wstring& renderedPath, const std::wstring& rawPath) {
+    g_pairViewRawPath = rawPath;
+    g_pairViewRenderedPath = renderedPath;
+    g_runtime.ForceRawDecode = true;
+    if (g_imageEngine) {
+        g_imageEngine->UpdateConfig(g_runtime);
+    }
+    // No SetForceRefresh here: the engine's RAW cache check already reloads a
+    // cached preview when full decode is wanted, and a cached FULL frame
+    // should be served instantly when navigating back to a visited pair.
+}
+
+// [RAW+JPEG Pairing] After a pair-compare session ends, land on the pair's
+// rendered face (also realigning the navigator index), not on the RAW that
+// occupied the right pane.
+static void ReturnToPairFaceAfterCompareExit(HWND hwnd) {
+    const bool wasPairSession = g_pairCompareSession;
+    g_pairCompareSession = false;
+    if (!wasPairSession || g_pairViewRawPath.empty()) return;
+    if (GetPaneContext(PaneSlot::Primary).path != g_pairViewRawPath) return;
+    const int idx = GetPaneContext(PaneSlot::Primary).navigator.FindIndex(g_pairViewRenderedPath);
+    if (idx >= 0) {
+        GetPaneContext(PaneSlot::Primary).navigator.SetIndex(idx);
+    }
+    LoadImageAsync(hwnd, g_pairViewRenderedPath.c_str());
+}
+
+static void ComparePairSideBySide(HWND hwnd, const std::wstring& renderedPath, const std::wstring& rawPath) {
+    const bool viewingRaw = (GetPaneContext(PaneSlot::Primary).path == rawPath);
+
+    // Track the pair so the load pipeline treats both sides as one photo
+    // (ForceRawDecode survives the cross-file loads)
+    g_pairViewRawPath = rawPath;
+    g_pairViewRenderedPath = renderedPath;
+    g_runtime.ForceRawDecode = true;
+
+    // EnterMode captures the CURRENT image into the left pane
+    AppContext::GetInstance().CompareCtrl->EnterMode(hwnd);
+    if (!IsCompareModeActive()) return; // refused (no resource / Titan image)
+    g_pairCompareSession = true;
+
+    // Armed immediately before each RAW load (by value: outlives the helper
+    // in async callbacks): a load interleaved by EnterMode's message pumping
+    // may have cleared the pair tracking.
+    auto armRawFullDecode = [renderedPath, rawPath]() {
+        ArmPairRawFullDecode(renderedPath, rawPath);
+    };
+
+    if (viewingRaw) {
+        // Left pane captured the RAW -- replace it with the rendered sibling,
+        // then reload the right pane as RAW at full decode. Unconditionally:
+        // stale metadata may claim full decode while the resident pixels are
+        // an upscaled preview; a genuine full frame re-hits the cache instantly.
+        AppContext::GetInstance().CompareCtrl->LoadImageIntoLeftSlot(hwnd, renderedPath, [hwnd, rawPath, armRawFullDecode](bool success) {
+            if (success) {
+                MarkCompareDirty();
+            }
+            armRawFullDecode();
+            LoadImageAsync(hwnd, rawPath.c_str());
+            RequestRepaint(PaintLayer::Image | PaintLayer::Static);
+        });
+    } else {
+        // Left pane captured the rendered image -- load the RAW on the right
+        armRawFullDecode();
+        LoadImageAsync(hwnd, rawPath.c_str());
+    }
+
+    // Concrete-format OSD labels, e.g. "JPG | CR3"
+    auto extLabel = [](const std::wstring& p) {
+        std::wstring label;
+        std::wstring_view ext = QuickView::ExtensionOf(p);
+        if (!ext.empty()) ext.remove_prefix(1);
+        for (wchar_t c : ext) label += (wchar_t)std::towupper(c);
+        return label;
+    };
+    const std::wstring leftLabel = extLabel(renderedPath);
+    const std::wstring rightLabel = extLabel(rawPath);
+    g_osd.ShowCompare(hwnd, leftLabel.c_str(), rightLabel.c_str(), D2D1::ColorF(D2D1::ColorF::White), 2000);
+    RequestRepaint(PaintLayer::All);
+}
+
 bool HandleHotkeyAction(HWND hwnd, HotkeyAction action) {
     [[maybe_unused]] bool ctrl = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
     [[maybe_unused]] bool shift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
@@ -12835,11 +12993,39 @@ bool HandleHotkeyAction(HWND hwnd, HotkeyAction action) {
     case HotkeyAction::ToggleCompare:
         if (IsCompareModeActive()) {
             AppContext::GetInstance().CompareCtrl->ExitMode(hwnd);
+            ReturnToPairFaceAfterCompareExit(hwnd);
         } else {
             AppContext::GetInstance().CompareCtrl->EnterMode(hwnd);
         }
         RequestRepaint(PaintLayer::All);
         return true;
+
+    case HotkeyAction::ComparePair: {
+        if (IsCompareModeActive()) return true;
+        const std::wstring& curPath = GetPaneContext(PaneSlot::Primary).path;
+        if (curPath.empty()) return true;
+        const auto& nav = GetPaneContext(PaneSlot::Primary).navigator;
+
+        // Resolve the pair from either side of it
+        std::wstring renderedPath, rawPath;
+        if (const auto* pairedRaw = nav.GetPairedRaw(FileNavigator::PathToImageID(curPath))) {
+            renderedPath = curPath;
+            rawPath = pairedRaw->path;
+        } else if (!g_pairViewRawPath.empty() && curPath == g_pairViewRawPath) {
+            renderedPath = g_pairViewRenderedPath;
+            rawPath = curPath;
+        } else {
+            std::wstring r = nav.GetResolvedPath(curPath);
+            if (r != curPath) {
+                renderedPath = std::move(r);
+                rawPath = curPath;
+            }
+        }
+        if (!rawPath.empty()) {
+            ComparePairSideBySide(hwnd, renderedPath, rawPath);
+        }
+        return true;
+    }
 
     case HotkeyAction::AlwaysOnTop:
         SendMessage(hwnd, WM_COMMAND, IDM_ALWAYS_ON_TOP, 0);

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -344,6 +344,10 @@ static std::wstring g_pairViewRenderedPath;
 static bool g_pairCompareSession = false;
 static void ReturnToPairFaceAfterCompareExit(HWND hwnd);
 static void ArmPairRawFullDecode(const std::wstring& renderedPath, const std::wstring& rawPath);
+// [RAW+JPEG Pairing] Delete handling for a folded pair (three-way choice) and
+// the shared refresh of the not-per-frame pair indicators (title + toolbar).
+static void HandlePairedDelete(HWND hwnd, const std::wstring& renderedPath, const std::wstring& rawPath);
+static void RefreshCurrentPairIndicators(HWND hwnd);
 
 bool HandleHotkeyAction(HWND hwnd, HotkeyAction action);
 bool g_preserveViewStateOnNextLoad = false;
@@ -2484,7 +2488,19 @@ DialogLayout CalculateDialogLayout(D2D1_SIZE_F size) {
     DialogLayout layout;
     const float s = g_uiScale;
     float dlgW = 350.0f * s;
-    
+
+    // Widen the box when the button row is wider than the default width (e.g.
+    // the RAW+JPEG pair-delete dialog's four buttons). Dialogs with up to three
+    // 95px buttons stay at 350px, so existing dialogs are unaffected.
+    {
+        const float btnW0 = 95.0f * s, btnGap0 = 12.0f * s;
+        const size_t nb = AppContext::GetInstance().Dialog.Buttons.size();
+        if (nb > 0) {
+            const float row = nb * btnW0 + (nb - 1) * btnGap0 + 40.0f * s; // 20px margin each side
+            if (row > dlgW) dlgW = row;
+        }
+    }
+
     // Calculate required height based on content
     // Title line: ~30px, Message lines: estimate based on length, Buttons: 50px, Padding: 40px
     float titleHeight = 30.0f * s;
@@ -9499,6 +9515,34 @@ SKIP_EDGE_NAV:;
                 break;
             }
 
+            // [RAW+JPEG Pairing] Deleting a folded pair is a three-way choice
+            // (whole pair / RAW only / rendered only) -- it must never silently
+            // recycle both, per the #201 discussion. Shown for a folded pair in
+            // single view whether the rendered face or the RAW face (via D) is
+            // on screen; the choice IS the confirmation, so it appears even when
+            // Confirm-on-Delete is off (the target is otherwise ambiguous).
+            // An in-progress edit (IsDirty -- OriginalFilePath is set on every
+            // clean load, so it is not the edit-mode signal) falls through to
+            // the edit-aware path below.
+            if (!IsCompareModeActive() &&
+                !GetPaneContext(PaneSlot::Primary).editState.IsDirty) {
+                auto& nav = GetPaneContext(PaneSlot::Primary).navigator;
+                const std::wstring cur = GetPaneContext(PaneSlot::Primary).path;
+                std::wstring renderedPath, rawPath;
+                if (const auto* pr = nav.GetPairedRaw(FileNavigator::PathToImageID(cur))) {
+                    renderedPath = cur;                       // viewing the rendered face
+                    rawPath = pr->path;
+                } else if (!g_pairViewRawPath.empty() && cur == g_pairViewRawPath &&
+                           !g_pairViewRenderedPath.empty()) {
+                    rawPath = cur;                            // viewing the RAW face
+                    renderedPath = g_pairViewRenderedPath;
+                }
+                if (!renderedPath.empty() && !rawPath.empty()) {
+                    HandlePairedDelete(hwnd, renderedPath, rawPath);
+                    break;
+                }
+            }
+
             // [v9.9 Fix] Handle Deletion during Edit/Transform
             // Determine actual target to recycle and temp file to map
             std::wstring recycleTarget = GetPaneContext(PaneSlot::Primary).path;
@@ -12634,21 +12678,14 @@ static void ReturnToPairFaceAfterCompareExit(HWND hwnd) {
     LoadImageAsync(hwnd, g_pairViewRenderedPath.c_str());
 }
 
-// [RAW+JPEG Pairing] The Settings toggle flipped: re-apply pairing to the open
-// folder right away and refresh the pair indicators that are not recomputed
-// per frame (window title, toolbar RAW button). Called from SettingsOverlay.
-void ApplyPairRawJpegSetting(HWND hwnd) {
-    if (!g_config.PairRawJpeg) {
-        // With pairing off no pair-view exists; drop stale tracking so a later
-        // navigation onto a former pair member cannot re-assert ForceRawDecode.
-        g_pairViewRawPath.clear();
-        g_pairViewRenderedPath.clear();
-    }
-
+// [RAW+JPEG Pairing] Refresh the pair indicators that are NOT recomputed each
+// frame -- the window-title "(+CR3)" suffix and the toolbar RAW button -- for
+// the current primary image. (The gallery badge, info panel and EXIF row are
+// per-frame and only need a repaint.) Compare mode routes through the existing
+// RefreshCompareRawUI instead.
+static void RefreshCurrentPairIndicators(HWND hwnd) {
     auto& pane = GetPaneContext(PaneSlot::Primary);
-    pane.navigator.RescanDirectory();
-
-    const std::wstring& cur = pane.path;
+    const std::wstring cur = pane.path;
     if (!cur.empty()) {
         const bool navHasPairedRaw = pane.navigator.HasPairedRaw(FileNavigator::PathToImageID(cur));
         const bool isPairedView = navHasPairedRaw
@@ -12658,8 +12695,7 @@ void ApplyPairRawJpegSetting(HWND hwnd) {
         if (IsCompareModeActive()) {
             RefreshCompareRawUI(hwnd);
         } else {
-            // The window title carries the "(+CR3)" suffix; rebuild it the way
-            // the load pipeline writes it.
+            // Rebuild the title the way the load pipeline writes it.
             std::wstring titleName = cur.substr(cur.find_last_of(L"\\/") + 1);
             if (const auto* pairedRaw = pane.navigator.GetPairedRaw(FileNavigator::PathToImageID(cur))) {
                 titleName += L" (" + FileNavigator::PairedRawLabel(*pairedRaw) + L")";
@@ -12669,11 +12705,130 @@ void ApplyPairRawJpegSetting(HWND hwnd) {
             SetWindowTextW(hwnd, titleBuf);
         }
     }
-
     RequestRepaint(PaintLayer::Static | PaintLayer::Dynamic);
     if (g_gallery.IsVisible()) {
         RequestRepaint(PaintLayer::Gallery);
     }
+}
+
+// [RAW+JPEG Pairing] The Settings toggle flipped: re-apply pairing to the open
+// folder right away and refresh the indicators. Called from SettingsOverlay.
+void ApplyPairRawJpegSetting(HWND hwnd) {
+    if (!g_config.PairRawJpeg) {
+        // With pairing off no pair-view exists; drop stale tracking so a later
+        // navigation onto a former pair member cannot re-assert ForceRawDecode.
+        g_pairViewRawPath.clear();
+        g_pairViewRenderedPath.clear();
+    }
+    GetPaneContext(PaneSlot::Primary).navigator.RescanDirectory();
+    RefreshCurrentPairIndicators(hwnd);
+}
+
+// [RAW+JPEG Pairing] Recycle one or more files in a single Shell operation
+// (double-null-terminated path list). Returns true on success.
+static bool RecycleFiles(const std::vector<std::wstring>& paths) {
+    if (paths.empty()) return false;
+    std::wstring buf;
+    for (const auto& p : paths) { buf.append(p); buf.push_back(L'\0'); }
+    buf.push_back(L'\0'); // final double-null terminator
+    SHFILEOPSTRUCTW op = {};
+    op.wFunc = FO_DELETE;
+    op.pFrom = buf.c_str();
+    op.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMATION | FOF_SILENT;
+    return SHFileOperationW(&op) == 0;
+}
+
+// [RAW+JPEG Pairing] Ask which file(s) of a folded pair to recycle and carry it
+// out. renderedPath is the visible (JPEG/HEIF) half, rawPath the hidden RAW.
+static void HandlePairedDelete(HWND hwnd, const std::wstring& renderedPath, const std::wstring& rawPath) {
+    auto& pane = GetPaneContext(PaneSlot::Primary);
+    auto& nav = pane.navigator;
+
+    auto baseName = [](const std::wstring& p) {
+        size_t slash = p.find_last_of(L"\\/");
+        return slash == std::wstring::npos ? p : p.substr(slash + 1);
+    };
+    auto extLabel = [](const std::wstring& p) {
+        std::wstring l;
+        std::wstring_view e = QuickView::ExtensionOf(p);
+        if (!e.empty()) e.remove_prefix(1); // drop the dot
+        for (wchar_t c : e) l += (wchar_t)std::towupper(c);
+        return l;
+    };
+    const std::wstring rLabel = extLabel(renderedPath); // e.g. JPG
+    const std::wstring wLabel = extLabel(rawPath);      // e.g. CR3
+
+    // Three explicit choices + Cancel -- never silently bind delete to both.
+    // Labels stay short so they fit the button width; English-only to match the
+    // surrounding delete dialog (its strings are not localized either).
+    const std::wstring btnPair = rLabel + L" + " + wLabel; // both
+    const std::wstring btnRaw  = wLabel + L" only";        // RAW only
+    const std::wstring btnJpg  = rLabel + L" only";        // rendered only
+    std::vector<DialogButton> btns;
+    btns.emplace_back(DialogResult::Yes, btnPair.c_str());
+    btns.emplace_back(DialogResult::Custom2, btnRaw.c_str());
+    btns.emplace_back(DialogResult::Custom1, btnJpg.c_str());
+    btns.emplace_back(DialogResult::Cancel, L"Cancel");
+
+    const DialogResult res = AppContext::GetInstance().DialogCtrl->ShowDialog(
+        hwnd, baseName(renderedPath), L"Delete which files?",
+        D2D1::ColorF(0.85f, 0.25f, 0.25f), btns, false, L"", L"");
+
+    if (res != DialogResult::Yes && res != DialogResult::Custom1 && res != DialogResult::Custom2) {
+        return; // Cancel / Esc
+    }
+    const bool delRendered = (res == DialogResult::Yes || res == DialogResult::Custom1);
+    const bool delRaw      = (res == DialogResult::Yes || res == DialogResult::Custom2);
+
+    // --- RAW only: the rendered file stays; the pair just un-folds ---
+    if (delRaw && !delRendered) {
+        const bool onRawFace = (pane.path != renderedPath); // showing the RAW via D
+        if (onRawFace) ReleaseImageResources();             // unlock the shown RAW first
+        if (!RecycleFiles({ rawPath })) return;
+        g_osd.Show(hwnd, AppStrings::OSD_MovedToRecycleBin, false);
+        g_pairViewRawPath.clear();
+        g_pairViewRenderedPath.clear();
+        nav.RescanDirectory();
+        if (onRawFace) {
+            const int idx = nav.FindIndex(renderedPath);
+            if (idx >= 0) nav.SetIndex(idx);
+            LoadImageAsync(hwnd, renderedPath.c_str()); // StartNavigation resets ForceRawDecode
+        } else {
+            RefreshCurrentPairIndicators(hwnd); // clear the "(+CR3)" title/toolbar in place
+        }
+        return;
+    }
+
+    // --- Rendered only, or the whole pair: the visible entry goes away ---
+    std::wstring nextPath = nav.PeekNext();
+    if (nextPath == renderedPath || nextPath == rawPath) nextPath = nav.PeekPrevious();
+    // Only this pair was in the folder (nav-loop wraps Peek back to it): fall
+    // through to the empty-folder path rather than reloading a deleted file.
+    if (nextPath == renderedPath || nextPath == rawPath) nextPath.clear();
+
+    std::vector<std::wstring> victims;
+    if (delRaw) victims.push_back(rawPath);
+    if (delRendered) victims.push_back(renderedPath);
+
+    ReleaseImageResources();
+    if (!RecycleFiles(victims)) return;
+    g_osd.Show(hwnd, AppStrings::OSD_MovedToRecycleBin, false);
+    g_pairViewRawPath.clear();
+    g_pairViewRenderedPath.clear();
+    pane.editState.Reset();
+    pane.view.Reset();
+    pane.resource.Reset();
+
+    // Rendered only: the RAW survives and now stands alone -- land on it.
+    if (delRendered && !delRaw) nextPath = rawPath;
+
+    if (!nextPath.empty()) {
+        nav.Initialize(nextPath, hwnd);
+        LoadImageAsync(hwnd, nav.GetResolvedPath(nextPath).c_str());
+    } else {
+        nav.Initialize(L"", hwnd); // folder emptied
+    }
+    RequestRepaint(PaintLayer::All);
 }
 
 static void ComparePairSideBySide(HWND hwnd, const std::wstring& renderedPath, const std::wstring& rawPath) {

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -586,7 +586,6 @@ static constexpr int HOTKEY_ID_ALPHA_DOWN = 0x0003;
 static void SetDialogCenter(float x, float y);
 static void ClearDialogCenter();
 
-bool IsRawFile(const std::wstring& path); // Forward declaration
 
 
 
@@ -2458,23 +2457,6 @@ bool FileExists(LPCWSTR path) {
     return (dwAttrib != INVALID_FILE_ATTRIBUTES && !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
 }
 
-bool IsRawFile(const std::wstring& path) {
-    size_t dot = path.find_last_of(L'.');
-    if (dot == std::wstring::npos) return false;
-    std::wstring ext = path.substr(dot);
-    std::transform(ext.begin(), ext.end(), ext.begin(), ::towlower);
-    
-    static const wchar_t* rawExts[] = { 
-        L".3fr", L".ari", L".arw", L".bay", L".braw", L".cr2", L".cr3", L".cap", L".data", L".dcs", L".dcr", 
-        L".dng", L".drf", L".eip", L".erf", L".fff", L".gpr", L".iiq", L".k25", L".kdc", L".mdc", L".mef", 
-        L".mos", L".mrw", L".nef", L".nrw", L".obm", L".orf", L".pef", L".ptx", L".pxn", L".r3d", L".raf", 
-        L".raw", L".rwl", L".rw2", L".rwz", L".sr2", L".srf", L".srw", L".sti", L".x3f"
-    };
-    for (const auto* e : rawExts) {
-        if (ext == e) return true;
-    }
-    return false;
-}
 
 void ReleaseImageResources() {
     GetPaneContext(PaneSlot::Primary).resource.Reset();
@@ -3702,8 +3684,9 @@ static constexpr FormatExtRule g_formatRules[] = {
     { L"ppm",  L".ppm", L".pnm", L".pgm", L".pbm" },
     { L"pbm",  L".pbm", L".pnm", L".pgm", L".ppm" },
     
-    // [v10.1] New: Support all RAW formats in extension check
-    { L"raw",  L".dng", L".arw", L".nef", L".cr2", L".cr3", L".raf" },
+    // [v10.1] RAW: any extension in QuickView::RAW_EXTENSIONS is accepted
+    // (special-cased in CheckExtensionMismatch); .dng stays the rename target.
+    { L"raw",  L".dng" },
     { L"dds",  L".dds" },
 };
 
@@ -3739,6 +3722,8 @@ bool CheckExtensionMismatch(std::wstring_view path, std::wstring_view format) {
     
     for (const auto& rule : g_formatRules) {
         if (fmt == rule.format || fmt.contains(rule.format)) {
+            // RAW covers 40+ extensions; defer to the central classification list
+            if (rule.format == L"raw" && QuickView::IsRawExtension(ext)) return false;
             if (ext == rule.primary) return false;
             if (!rule.alt1.empty() && ext == rule.alt1) return false;
             if (!rule.alt2.empty() && ext == rule.alt2) return false;
@@ -8379,7 +8364,7 @@ SKIP_EDGE_NAV:;
                     if (IsCompareModeActive()) {
                         bool isLeft = (AppContext::GetInstance().Compare.selectedPane == ComparePane::Left);
                         const std::wstring& selPath = isLeft ? GetPaneContext(PaneSlot::Left).path : GetPaneContext(PaneSlot::Primary).path;
-                        if (!IsRawFile(selPath)) break; // Selected pane is not RAW, ignore
+                        if (!QuickView::IsRawPath(selPath)) break; // Selected pane is not RAW, ignore
                         // Point context to selected pane, then delegate to IDM_RENDER_RAW
                         AppContext::GetInstance().Compare.contextPane = AppContext::GetInstance().Compare.selectedPane;
                         SendMessage(hwnd, WM_COMMAND, IDM_RENDER_RAW, 0);
@@ -9021,7 +9006,7 @@ SKIP_EDGE_NAV:;
 
         if (hasImage && !targetPath.empty()) {
              extensionFixNeeded = CheckExtensionMismatch(targetPath, targetFmt);
-             isRaw = IsRawFile(targetPath);
+             isRaw = QuickView::IsRawPath(targetPath);
         }
         
         bool isPixelArtMode = GetCurrentPixelArtState(hwnd);
@@ -11341,7 +11326,7 @@ void StartNavigation(HWND hwnd, std::wstring path, [[maybe_unused]] bool showOSD
     
     // Update Toolbar State for RAW
     // [Fix] Ensure RAW button visibility is updated immediately on navigation
-    g_toolbar.SetRawState(IsRawFile(path), g_runtime.ForceRawDecode);
+    g_toolbar.SetRawState(QuickView::IsRawPath(path), g_runtime.ForceRawDecode);
     if (IsCompareModeActive()) {
         RefreshCompareRawUI(hwnd);
     }

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -12634,6 +12634,48 @@ static void ReturnToPairFaceAfterCompareExit(HWND hwnd) {
     LoadImageAsync(hwnd, g_pairViewRenderedPath.c_str());
 }
 
+// [RAW+JPEG Pairing] The Settings toggle flipped: re-apply pairing to the open
+// folder right away and refresh the pair indicators that are not recomputed
+// per frame (window title, toolbar RAW button). Called from SettingsOverlay.
+void ApplyPairRawJpegSetting(HWND hwnd) {
+    if (!g_config.PairRawJpeg) {
+        // With pairing off no pair-view exists; drop stale tracking so a later
+        // navigation onto a former pair member cannot re-assert ForceRawDecode.
+        g_pairViewRawPath.clear();
+        g_pairViewRenderedPath.clear();
+    }
+
+    auto& pane = GetPaneContext(PaneSlot::Primary);
+    pane.navigator.RescanDirectory();
+
+    const std::wstring& cur = pane.path;
+    if (!cur.empty()) {
+        const bool navHasPairedRaw = pane.navigator.HasPairedRaw(FileNavigator::PathToImageID(cur));
+        const bool isPairedView = navHasPairedRaw
+            || (!g_pairViewRawPath.empty() && cur == g_pairViewRawPath);
+        g_toolbar.SetRawState(QuickView::IsRawPath(cur) || navHasPairedRaw,
+                              g_runtime.ForceRawDecode, isPairedView);
+        if (IsCompareModeActive()) {
+            RefreshCompareRawUI(hwnd);
+        } else {
+            // The window title carries the "(+CR3)" suffix; rebuild it the way
+            // the load pipeline writes it.
+            std::wstring titleName = cur.substr(cur.find_last_of(L"\\/") + 1);
+            if (const auto* pairedRaw = pane.navigator.GetPairedRaw(FileNavigator::PathToImageID(cur))) {
+                titleName += L" (" + FileNavigator::PairedRawLabel(*pairedRaw) + L")";
+            }
+            wchar_t titleBuf[2048];
+            swprintf_s(titleBuf, L"%s - %s", titleName.c_str(), g_szWindowTitle);
+            SetWindowTextW(hwnd, titleBuf);
+        }
+    }
+
+    RequestRepaint(PaintLayer::Static | PaintLayer::Dynamic);
+    if (g_gallery.IsVisible()) {
+        RequestRepaint(PaintLayer::Gallery);
+    }
+}
+
 static void ComparePairSideBySide(HWND hwnd, const std::wstring& renderedPath, const std::wstring& rawPath) {
     const bool viewingRaw = (GetPaneContext(PaneSlot::Primary).path == rawPath);
 

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -3962,6 +3962,7 @@ void SaveConfig() {
     WritePrivateProfileStringW(L"Image", L"GamutWarningColorB", std::to_wstring(g_config.GamutWarningColorB).c_str(), iniPath.c_str());
     WritePrivateProfileStringW(L"Image", L"CustomEditorPath", g_config.CustomEditorPath.c_str(), iniPath.c_str());
     WritePrivateProfileStringW(L"Image", L"ForceRawDecode", g_config.ForceRawDecode ? L"1" : L"0", iniPath.c_str());
+    WritePrivateProfileStringW(L"Image", L"PairRawJpeg", g_config.PairRawJpeg ? L"1" : L"0", iniPath.c_str());
     WritePrivateProfileStringW(L"Image", L"AlwaysSaveLossless", g_config.AlwaysSaveLossless ? L"1" : L"0", iniPath.c_str());
     WritePrivateProfileStringW(L"Image", L"AlwaysSaveEdgeAdapted", g_config.AlwaysSaveEdgeAdapted ? L"1" : L"0", iniPath.c_str());
     WritePrivateProfileStringW(L"Image", L"AlwaysSaveLossy", g_config.AlwaysSaveLossy ? L"1" : L"0", iniPath.c_str());
@@ -4243,6 +4244,7 @@ void LoadConfig() {
     g_config.CustomEditorPath = customEditorPath;
 
     g_config.ForceRawDecode = GetPrivateProfileIntW(L"Image", L"ForceRawDecode", 0, iniPath.c_str()) != 0;
+    g_config.PairRawJpeg = GetPrivateProfileIntW(L"Image", L"PairRawJpeg", 0, iniPath.c_str()) != 0;
     g_config.AlwaysSaveLossless = GetPrivateProfileIntW(L"Image", L"AlwaysSaveLossless", 0, iniPath.c_str()) != 0;
     g_config.AlwaysSaveEdgeAdapted = GetPrivateProfileIntW(L"Image", L"AlwaysSaveEdgeAdapted", 0, iniPath.c_str()) != 0;
     g_config.AlwaysSaveLossy = GetPrivateProfileIntW(L"Image", L"AlwaysSaveLossy", 0, iniPath.c_str()) != 0;

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -10452,14 +10452,17 @@ void ProcessEngineEvents(HWND hwnd) {
                 // UI Text Logic
                 wchar_t titleBuf[2048];
                 if (isPreview) {
-                    swprintf_s(titleBuf, L"Loading... %s - %s", 
-                        evt.filePath.substr(evt.filePath.find_last_of(L"\\/") + 1).c_str(), 
+                    swprintf_s(titleBuf, L"Loading... %s - %s",
+                        evt.filePath.substr(evt.filePath.find_last_of(L"\\/") + 1).c_str(),
                         g_szWindowTitle);
                 } else {
-                     swprintf_s(titleBuf, L"%s - %s", 
-                        evt.filePath.substr(evt.filePath.find_last_of(L"\\/") + 1).c_str(), 
-                        g_szWindowTitle);
-                     
+                     // [RAW+JPEG Pairing] Flag the hidden RAW in the title, e.g. "IMG_001.JPG (+CR3)"
+                     std::wstring titleName = evt.filePath.substr(evt.filePath.find_last_of(L"\\/") + 1);
+                     if (const auto* pairedRaw = GetPaneContext(PaneSlot::Primary).navigator.GetPairedRaw(FileNavigator::PathToImageID(evt.filePath))) {
+                         titleName += L" (" + FileNavigator::PairedRawLabel(*pairedRaw) + L")";
+                     }
+                     swprintf_s(titleBuf, L"%s - %s", titleName.c_str(), g_szWindowTitle);
+
                      g_isImageScaled = evt.isScaled;
                 }
                 SetWindowTextW(hwnd, titleBuf);

--- a/QuickView/main.cpp
+++ b/QuickView/main.cpp
@@ -5610,6 +5610,12 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, [[maybe_unused]] LPWSTR lpCm
     AppStrings::Init();
     AppStrings::SetLanguage((AppStrings::Language)g_config.Language);
 
+    // [RAW+JPEG Pairing] Capture-time fallback reader (LibRaw for RAW, WIC
+    // for HEIF etc.; lives in ImageLoader.cpp -- FileNavigator itself must
+    // stay LibRaw/WIC-free for the unit-test binary)
+    extern int64_t ReadCaptureTimeFallback(const wchar_t* filePath);
+    FileNavigator::SetCaptureTimeFallbackReader(&ReadCaptureTimeFallback);
+
     // Now safe to start ETW
     EtwScope etwScope;
 

--- a/tests/FileNavigatorTests.cpp
+++ b/tests/FileNavigatorTests.cpp
@@ -265,6 +265,55 @@ TEST(RawJpegPairingTest, MultiDotStemsMatchExactly) {
     EXPECT_TRUE(paired.empty());
 }
 
+TEST(RawJpegPairingTest, ParseExifDateTime) {
+    const int64_t a = FileNavigator::ParseExifDateTime("2026:07:09 14:30:45");
+    const int64_t b = FileNavigator::ParseExifDateTime("2026:07:09 14:30:45");
+    const int64_t c = FileNavigator::ParseExifDateTime("2026:07:09 14:30:48");
+    ASSERT_NE(a, 0);
+    EXPECT_EQ(a, b);            // deterministic
+    EXPECT_EQ(c - a, 3);        // second-level arithmetic
+    // Unparsable inputs
+    EXPECT_EQ(FileNavigator::ParseExifDateTime(""), 0);
+    EXPECT_EQ(FileNavigator::ParseExifDateTime("not a date"), 0);
+    EXPECT_EQ(FileNavigator::ParseExifDateTime("2026-07-09 14:30:45"), 0); // wrong separator
+    EXPECT_EQ(FileNavigator::ParseExifDateTime("1899:01:01 00:00:00"), 0); // pre-epoch
+}
+
+TEST(RawJpegPairingTest, PairVerificationIsStrict) {
+    // One shutter actuation writes the identical DateTimeOriginal into both
+    // files: only an exact match passes.
+    EXPECT_FALSE(FileNavigator::PairVerificationFails(1000, 1000));
+    // Any difference splits the pair, even one second
+    EXPECT_TRUE(FileNavigator::PairVerificationFails(1000, 1001));
+    EXPECT_TRUE(FileNavigator::PairVerificationFails(1001, 1000));
+    EXPECT_TRUE(FileNavigator::PairVerificationFails(1000, 5000));
+    // An unreadable side fails verification: a same-name file without a
+    // readable capture time is likely not the camera's output of this shot
+    EXPECT_TRUE(FileNavigator::PairVerificationFails(0, 0));
+    EXPECT_TRUE(FileNavigator::PairVerificationFails(0, 1000));
+    EXPECT_TRUE(FileNavigator::PairVerificationFails(1000, 0));
+}
+
+TEST(RawJpegPairingTest, VerifiedMismatchBlacklistPreventsFold) {
+    std::vector<FileNavigator::SortEntry> entries = {
+        MakeEntry(L"C:\\p\\IMG_001.JPG"),
+        MakeEntry(L"C:\\p\\IMG_001.CR3"),
+        MakeEntry(L"C:\\p\\IMG_002.JPG"),
+        MakeEntry(L"C:\\p\\IMG_002.NEF"),
+    };
+    // IMG_001's capture times were verified as mismatching
+    std::unordered_set<ImageID> skip = { ComputePathHash(L"C:\\p\\IMG_001.JPG") };
+    std::unordered_map<ImageID, FileNavigator::PairedRaw> paired;
+    FileNavigator::ApplyRawJpegPairing(entries, paired, &skip);
+
+    // IMG_001 stays split; IMG_002 still folds
+    ASSERT_EQ(entries.size(), 3u);
+    EXPECT_EQ(paired.size(), 1u);
+    EXPECT_TRUE(paired.count(ComputePathHash(L"C:\\p\\IMG_002.JPG")) == 1);
+    EXPECT_TRUE(std::any_of(entries.begin(), entries.end(),
+        [](const auto& e) { return e.p == L"C:\\p\\IMG_001.CR3"; }));
+}
+
 // Integration: pairing through FileNavigator::Initialize on a real directory
 TEST(RawJpegPairingTest, InitializePairsAndRedirectsRawOpen) {
     namespace fs = std::filesystem;

--- a/tests/FileNavigatorTests.cpp
+++ b/tests/FileNavigatorTests.cpp
@@ -144,6 +144,190 @@ TEST(FileNavigatorTest, SortEntries_VirtualPaths_ByType) {
 }
 
 
+// ============================================================================
+// [RAW+JPEG Pairing] Unit tests for the pairing pass (pure, no disk I/O)
+// ============================================================================
+
+static FileNavigator::SortEntry MakeEntry(const std::wstring& path, uintmax_t size = 100) {
+    FileNavigator::SortEntry e;
+    e.p = path;
+    e.s = size;
+    std::filesystem::path fsPath(path);
+    e.t = fsPath.extension().wstring();
+    std::transform(e.t.begin(), e.t.end(), e.t.begin(), [](wchar_t c){ return std::towlower(c); });
+    return e;
+}
+
+TEST(RawJpegPairingTest, StrictOneToOnePairs) {
+    std::vector<FileNavigator::SortEntry> entries = {
+        MakeEntry(L"C:\\p\\IMG_001.JPG"),
+        MakeEntry(L"C:\\p\\IMG_001.CR3"),
+        MakeEntry(L"C:\\p\\IMG_002.JPG"),
+    };
+    std::unordered_map<ImageID, FileNavigator::PairedRaw> paired;
+    FileNavigator::ApplyRawJpegPairing(entries, paired);
+
+    ASSERT_EQ(entries.size(), 2u); // CR3 folded away
+    EXPECT_EQ(entries[0].p, L"C:\\p\\IMG_001.JPG");
+    EXPECT_EQ(entries[1].p, L"C:\\p\\IMG_002.JPG");
+
+    ASSERT_EQ(paired.size(), 1u);
+    const auto* raw = &paired.at(ComputePathHash(L"C:\\p\\IMG_001.JPG"));
+    EXPECT_EQ(raw->path, L"C:\\p\\IMG_001.CR3");
+    EXPECT_EQ(raw->id, ComputePathHash(L"C:\\p\\IMG_001.CR3"));
+}
+
+TEST(RawJpegPairingTest, CaseInsensitiveStemAndExtension) {
+    std::vector<FileNavigator::SortEntry> entries = {
+        MakeEntry(L"C:\\p\\dsc_0007.nef"),
+        MakeEntry(L"C:\\p\\DSC_0007.JPG"),
+    };
+    std::unordered_map<ImageID, FileNavigator::PairedRaw> paired;
+    FileNavigator::ApplyRawJpegPairing(entries, paired);
+    EXPECT_EQ(entries.size(), 1u);
+    EXPECT_EQ(paired.size(), 1u);
+}
+
+TEST(RawJpegPairingTest, AmbiguousGroupsStayVisible) {
+    // Two rendered stills against one RAW -> no pair, everything visible
+    std::vector<FileNavigator::SortEntry> entries = {
+        MakeEntry(L"C:\\p\\IMG_001.JPG"),
+        MakeEntry(L"C:\\p\\IMG_001.HEIC"),
+        MakeEntry(L"C:\\p\\IMG_001.CR3"),
+    };
+    std::unordered_map<ImageID, FileNavigator::PairedRaw> paired;
+    FileNavigator::ApplyRawJpegPairing(entries, paired);
+    EXPECT_EQ(entries.size(), 3u);
+    EXPECT_TRUE(paired.empty());
+
+    // Two RAWs against one rendered -> same
+    entries = {
+        MakeEntry(L"C:\\p\\IMG_002.JPG"),
+        MakeEntry(L"C:\\p\\IMG_002.CR3"),
+        MakeEntry(L"C:\\p\\IMG_002.DNG"),
+    };
+    FileNavigator::ApplyRawJpegPairing(entries, paired);
+    EXPECT_EQ(entries.size(), 3u);
+    EXPECT_TRUE(paired.empty());
+}
+
+TEST(RawJpegPairingTest, NonWhitelistedNeitherPairsNorBlocks) {
+    // A same-stem .png (not camera-written, origin unknown) or .tif
+    // (RAW-derived export) must not become the visible half, and must not
+    // break the JPG+RAW pair.
+    std::vector<FileNavigator::SortEntry> entries = {
+        MakeEntry(L"C:\\p\\IMG_001.JPG"),
+        MakeEntry(L"C:\\p\\IMG_001.CR3"),
+        MakeEntry(L"C:\\p\\IMG_001.png"),
+        MakeEntry(L"C:\\p\\IMG_001.tif"),
+    };
+    std::unordered_map<ImageID, FileNavigator::PairedRaw> paired;
+    FileNavigator::ApplyRawJpegPairing(entries, paired);
+    ASSERT_EQ(entries.size(), 3u); // only the CR3 folded
+    EXPECT_EQ(paired.size(), 1u);
+
+    // RAW + only a .tif sibling -> nothing pairs, RAW stays visible
+    entries = {
+        MakeEntry(L"C:\\p\\IMG_003.tif"),
+        MakeEntry(L"C:\\p\\IMG_003.ARW"),
+    };
+    FileNavigator::ApplyRawJpegPairing(entries, paired);
+    EXPECT_EQ(entries.size(), 2u);
+    EXPECT_TRUE(paired.empty());
+}
+
+TEST(RawJpegPairingTest, EarlyExitWhenNoMix) {
+    // Only rendered files -> untouched
+    std::vector<FileNavigator::SortEntry> entries = {
+        MakeEntry(L"C:\\p\\a.jpg"), MakeEntry(L"C:\\p\\b.jpg"),
+    };
+    std::unordered_map<ImageID, FileNavigator::PairedRaw> paired;
+    FileNavigator::ApplyRawJpegPairing(entries, paired);
+    EXPECT_EQ(entries.size(), 2u);
+    EXPECT_TRUE(paired.empty());
+
+    // Only RAWs -> untouched
+    entries = { MakeEntry(L"C:\\p\\a.cr3"), MakeEntry(L"C:\\p\\b.nef") };
+    FileNavigator::ApplyRawJpegPairing(entries, paired);
+    EXPECT_EQ(entries.size(), 2u);
+    EXPECT_TRUE(paired.empty());
+}
+
+TEST(RawJpegPairingTest, MultiDotStemsMatchExactly) {
+    // "photo.bak.jpg" pairs only with "photo.bak.cr3", not "photo.cr3"
+    std::vector<FileNavigator::SortEntry> entries = {
+        MakeEntry(L"C:\\p\\photo.bak.jpg"),
+        MakeEntry(L"C:\\p\\photo.cr3"),
+    };
+    std::unordered_map<ImageID, FileNavigator::PairedRaw> paired;
+    FileNavigator::ApplyRawJpegPairing(entries, paired);
+    EXPECT_EQ(entries.size(), 2u);
+    EXPECT_TRUE(paired.empty());
+}
+
+// Integration: pairing through FileNavigator::Initialize on a real directory
+TEST(RawJpegPairingTest, InitializePairsAndRedirectsRawOpen) {
+    namespace fs = std::filesystem;
+    const bool oldPair = g_config.PairRawJpeg;
+    const int oldSortOrder = g_runtime.SortOrder;
+    const bool oldSortDesc = g_runtime.SortDescending;
+    g_runtime.SortOrder = 1;
+    g_runtime.SortDescending = false;
+
+    fs::path tempDir = fs::current_path() / "test_pairing_dir";
+    std::error_code ec;
+    fs::create_directory(tempDir, ec);
+    ASSERT_FALSE(ec);
+
+    fs::path jpg1 = tempDir / "IMG_001.JPG";
+    fs::path raw1 = tempDir / "IMG_001.CR3";
+    fs::path jpg2 = tempDir / "IMG_002.JPG";
+    std::ofstream(jpg1).close();
+    std::ofstream(raw1).close();
+    std::ofstream(jpg2).close();
+
+    // Flag off: stock behavior, all three visible
+    g_config.PairRawJpeg = false;
+    {
+        FileNavigator nav;
+        nav.Initialize(jpg1.wstring(), nullptr);
+        EXPECT_EQ(nav.Count(), 3u);
+        EXPECT_EQ(nav.PairedRawCount(), 0u);
+    }
+
+    // Flag on: pair folds, metadata queryable via the rendered file's ImageID
+    g_config.PairRawJpeg = true;
+    {
+        FileNavigator nav;
+        nav.Initialize(jpg1.wstring(), nullptr);
+        ASSERT_EQ(nav.Count(), 2u);
+        EXPECT_EQ(nav.GetFile(0), jpg1.wstring());
+        EXPECT_EQ(nav.GetFile(1), jpg2.wstring());
+
+        const ImageID jpgId = nav.GetImageID(0);
+        ASSERT_TRUE(nav.HasPairedRaw(jpgId));
+        EXPECT_EQ(nav.GetPairedRaw(jpgId)->path, raw1.wstring());
+        EXPECT_FALSE(nav.HasPairedRaw(nav.GetImageID(1)));
+
+        // Opening the hidden RAW itself lands on its rendered sibling: both
+        // the navigator index and the path the viewer should actually load
+        // (GetResolvedPath is what main.cpp feeds to LoadImageAsync).
+        FileNavigator nav2;
+        nav2.Initialize(raw1.wstring(), nullptr);
+        ASSERT_EQ(nav2.Count(), 2u);
+        EXPECT_EQ(nav2.Index(), 0);
+        EXPECT_EQ(nav2.GetFile(nav2.Index()), jpg1.wstring());
+        EXPECT_EQ(nav2.GetResolvedPath(raw1.wstring()), jpg1.wstring());
+        // Non-hidden paths resolve to themselves
+        EXPECT_EQ(nav2.GetResolvedPath(jpg2.wstring()), jpg2.wstring());
+    }
+
+    fs::remove_all(tempDir, ec);
+    g_config.PairRawJpeg = oldPair;
+    g_runtime.SortOrder = oldSortOrder;
+    g_runtime.SortDescending = oldSortDesc;
+}
+
 // Helper to create a valid uncompressed Zip archive programmatically
 static bool CreateMockZip(const std::wstring& zipPath, const std::string& entryName) {
     std::ofstream fs(zipPath, std::ios::binary);

--- a/tests/SupportedExtensionsTests.cpp
+++ b/tests/SupportedExtensionsTests.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+#include "SupportedExtensions.h"
+
+#include <set>
+#include <string>
+
+using namespace QuickView;
+
+// The compile-time behavior is already pinned by the static_asserts in
+// SupportedExtensions.h; these tests cover list integrity and runtime edges.
+
+TEST(SupportedExtensionsTest, NoDuplicateExtensionsAcrossSegments) {
+    // Every extension must appear exactly once across SUPPORTED + EXTENDED_RAW
+    // (single source of truth: segments must not overlap).
+    std::set<std::wstring> seen;
+    for (const auto& e : SUPPORTED_EXTENSIONS) {
+        EXPECT_TRUE(seen.insert(std::wstring(e)).second)
+            << "duplicate in SUPPORTED_EXTENSIONS: " << std::string(e.begin(), e.end());
+    }
+    for (const auto& e : detail::EXTENDED_RAW_EXTENSIONS) {
+        EXPECT_TRUE(seen.insert(std::wstring(e)).second)
+            << "extended RAW ext duplicates a supported ext: " << std::string(e.begin(), e.end());
+    }
+}
+
+TEST(SupportedExtensionsTest, AllListedExtensionsAreLowercaseWithDot) {
+    auto check = [](std::wstring_view e) {
+        ASSERT_GE(e.size(), 2u);
+        EXPECT_EQ(e[0], L'.');
+        for (wchar_t c : e.substr(1)) {
+            EXPECT_TRUE((c >= L'a' && c <= L'z') || (c >= L'0' && c <= L'9'));
+        }
+    };
+    for (const auto& e : SUPPORTED_EXTENSIONS) check(e);
+    for (const auto& e : RAW_EXTENSIONS) check(e);
+}
+
+TEST(SupportedExtensionsTest, EveryBrowsableRawIsClassifiedAsRaw) {
+    // Regression guard for the .crw class of bug: anything QuickView browses
+    // as camera RAW must also classify as RAW.
+    for (const auto& e : detail::CAMERA_RAW_EXTENSIONS) {
+        EXPECT_TRUE(IsRawExtension(e)) << std::string(e.begin(), e.end());
+    }
+}
+
+TEST(SupportedExtensionsTest, IsRawExtensionCases) {
+    EXPECT_TRUE(IsRawExtension(L".crw"));  // was missing from the old IsRawFile
+    EXPECT_TRUE(IsRawExtension(L".cr3"));
+    EXPECT_TRUE(IsRawExtension(L".NEF"));  // case-insensitive
+    EXPECT_TRUE(IsRawExtension(L".braw")); // extended (non-browsable) RAW
+    EXPECT_FALSE(IsRawExtension(L".jpg"));
+    EXPECT_FALSE(IsRawExtension(L".tif")); // TIFF is deliberately not RAW
+    EXPECT_FALSE(IsRawExtension(L""));
+    EXPECT_FALSE(IsRawExtension(L"arw")); // missing dot is not an extension
+}
+
+TEST(SupportedExtensionsTest, ExtensionOfEdgeCases) {
+    EXPECT_EQ(ExtensionOf(L"C:\\photos\\IMG_0001.NEF"), L".NEF");
+    EXPECT_EQ(ExtensionOf(L"IMG_0001.jpg"), L".jpg");
+    EXPECT_EQ(ExtensionOf(L"noextension"), L"");
+    EXPECT_EQ(ExtensionOf(L""), L"");
+    EXPECT_EQ(ExtensionOf(L"C:\\dir.raw\\readme"), L"");          // dot only in directory
+    EXPECT_EQ(ExtensionOf(L"C:\\a\\manga.cbz|12|page01.png"), L".png"); // VFS virtual path
+    EXPECT_EQ(ExtensionOf(L".arw"), L".arw");                     // bare dotfile
+    EXPECT_EQ(ExtensionOf(L"photo.bak.jpg"), L".jpg");            // last dot wins
+}
+
+TEST(SupportedExtensionsTest, IsRawPathCases) {
+    EXPECT_TRUE(IsRawPath(L"C:\\Photos\\IMG_0001.NEF"));
+    EXPECT_TRUE(IsRawPath(L"C:\\Photos\\img_0001.cr3"));
+    EXPECT_FALSE(IsRawPath(L"C:\\Photos\\IMG_0001.JPG"));
+    EXPECT_FALSE(IsRawPath(L"C:\\dir.nef\\file"));
+}
+
+TEST(SupportedExtensionsTest, HeifAndArchiveHelpers) {
+    EXPECT_TRUE(IsHeifExtension(L".heic"));
+    EXPECT_TRUE(IsHeifExtension(L".HIF"));
+    EXPECT_FALSE(IsHeifExtension(L".jpg"));
+    EXPECT_TRUE(IsHeifPath(L"C:\\x\\IMG_1234.HEIC"));
+
+    EXPECT_TRUE(IsArchiveExtension(L".cbz"));
+    EXPECT_TRUE(IsArchivePath(L"C:\\comics\\manga.CBZ"));
+    EXPECT_FALSE(IsArchivePath(L"C:\\comics\\page.png"));
+}
+
+TEST(SupportedExtensionsTest, FilterStringIsWellFormed) {
+    const std::wstring filter = GetSupportedExtensionsFilter();
+    EXPECT_NE(filter.find(L"*.jpg"), std::wstring::npos);
+    EXPECT_NE(filter.find(L"*.crw"), std::wstring::npos);
+    EXPECT_NE(filter.find(L"*.rar"), std::wstring::npos);
+    // Extended (non-browsable) RAW must NOT be offered by the folder filter
+    EXPECT_EQ(filter.find(L"*.braw"), std::wstring::npos);
+}

--- a/tests/SupportedExtensionsTests.cpp
+++ b/tests/SupportedExtensionsTests.cpp
@@ -83,6 +83,28 @@ TEST(SupportedExtensionsTest, HeifAndArchiveHelpers) {
     EXPECT_FALSE(IsArchivePath(L"C:\\comics\\page.png"));
 }
 
+TEST(SupportedExtensionsTest, RenderedPairWhitelist) {
+    // Camera-rendered stills that may pair with a RAW
+    EXPECT_TRUE(IsRenderedPairExtension(L".jpg"));
+    EXPECT_TRUE(IsRenderedPairExtension(L".JPEG"));
+    EXPECT_TRUE(IsRenderedPairExtension(L".hif"));  // Canon/Nikon/Sony/Fuji HEIF
+    EXPECT_TRUE(IsRenderedPairExtension(L".heic")); // Apple / newer Panasonic
+    EXPECT_TRUE(IsRenderedPairExtension(L".heif"));
+    // Never pair a RAW behind these
+    EXPECT_FALSE(IsRenderedPairExtension(L".png"));  // not camera-written beside a RAW
+    EXPECT_FALSE(IsRenderedPairExtension(L".psd"));  // edit
+    EXPECT_FALSE(IsRenderedPairExtension(L".tif"));  // RAW-derived export
+    EXPECT_FALSE(IsRenderedPairExtension(L".svg"));
+    EXPECT_FALSE(IsRenderedPairExtension(L".dng"));  // RAW itself
+    // Every whitelist entry must be a browsable supported extension
+    for (const auto& e : RENDERED_PAIR_EXTENSIONS) {
+        bool supported = false;
+        for (const auto& s : SUPPORTED_EXTENSIONS) supported |= (e == s);
+        EXPECT_TRUE(supported) << std::string(e.begin(), e.end());
+        EXPECT_FALSE(IsRawExtension(e));
+    }
+}
+
 TEST(SupportedExtensionsTest, FilterStringIsWellFormed) {
     const std::wstring filter = GetSupportedExtensionsFilter();
     EXPECT_NE(filter.find(L"*.jpg"), std::wstring::npos);


### PR DESCRIPTION
# RAW + JPEG pairing (#201)

## Summary

Fold a RAW file and its same-name in-camera rendered image (JPEG/HEIF) into a single logical photo, so a shooter who saves RAW+JPEG sees one entry per shot instead of two. The rendered image is what you browse; the RAW rides along, one keystroke away for a full decode or a side-by-side check. Opt-in via a new **Settings → Image → RAW+JPEG Pairing** toggle, **off by default** — with it off, QuickView behaves exactly as before.

This implements the three-phase model you outlined on #201 (cheap early-out → in-memory same-stem match → asynchronous EXIF verification), staged as 9 reviewable commits.

## What it does (user-facing)

- **One entry per shot.** With pairing on, a folder of `IMG_1234.JPG` + `IMG_1234.CR3` lists a single item — the JPEG — and the RAW is hidden behind it. Sorting and navigation treat the pair as one.
- **Delete asks which files.** Delete on a folded pair opens a three-way choice — whole pair / RAW only / rendered only — never silently recycling both (see Design notes).
- **Always visible which RAW is attached.** The hidden RAW is surfaced everywhere with its concrete format, gallery badge `+CR3`, window title `IMG_1234.JPG (+CR3)`, info panel (lite) plain-text `(+CR3)`, and a dedicated 🔗 row in the EXIF panel.
- **Reach the RAW when you want it.** The existing RAW toolbar button and a new rebindable **RenderRaw** hotkey (default `D`, under *View Modes*) switch the shown pair between the rendered and the RAW at full decode.
- **Compare the two.** A new rebindable **ComparePair** hotkey (default `Shift+C`, next to *Toggle Compare*) opens compare mode with the rendered image left and the RAW at full decode right. Arrow keys then move **both** panes to the neighbouring pair.
- **Wrong pairs split themselves.** Capture times are verified in the background; a mismatch un-folds that pair (see below).

## Design notes

### Rendered-half whitelist (not subtraction)

A file only qualifies as the visible half of a pair if it is a format a camera actually writes next to a RAW — an explicit whitelist, not "everything that isn't RAW or archive":

```
.jpg  .jpeg  .heic  .heif  .hif
```

`.hif` is Canon's HEIF extension; `.heic/.heif` cover Apple/Sony/others. TIFF is deliberately **excluded** — no modern camera captures `.tif`; a same-name `.tif` beside a RAW is a RAW-derived export, so folding it would hide a developed file. `.png/.psd/.svg` are excluded for the same "not camera-written beside a RAW" reason. The rationale for each inclusion/exclusion lives inline in `SupportedExtensions.h`.

### Strict 1:1 folding

A pair folds only when a basename has **exactly one** RAW and **exactly one** whitelisted rendered still. Anything ambiguous (two RAWs, two JPEGs, a non-whitelisted sibling) is left fully expanded. Pure and unit-tested.

### Delete is a three-way choice, never silently bound

Because a folded pair is two files behind one entry, Delete on it opens a choice — **whole pair** / **RAW only** / **rendered only** — instead of guessing. This is the delete model we proposed on #201 (delete both when the shot is worthless; keep the JPEG and drop the RAW when there's no post to do; keep the RAW and drop the JPEG after a pano/HDR merge). The choice *is* the confirmation. "RAW only" leaves the rendered file on screen and un-folds the pair in place; "rendered only" leaves the RAW standing alone as the current item; "both" lands on the neighbour. Recycle-bin undo (FOF_ALLOWUNDO) throughout.

### Asynchronous exact-second verification

Same-name isn't proof of same shot, so each folded pair is verified off the UI thread: rendered capture time via the existing easyexif (non-JPEG goes to a WIC/LibRaw), RAW capture time via LibRaw. The match is **exact-second** — files from one shutter actuation share the same `DateTimeOriginal` to the second; anything else (including an unreadable time on either side) un-folds the pair. Splits are delivered to the UI thread through the exact same atomic list-swap channel the directory watcher already uses, with a generation counter to cancel a superseded pass.

### Refactor: centralized extension classification (commit 1)

Per our discussion on #201, RAW/HEIF/archive/rendered classification is now a single source of truth in `SupportedExtensions.h`: `constexpr` segment arrays concatenated at compile time, with `constexpr` predicates (`IsRawExtension`, `IsRenderedPairExtension`, …) and `static_assert` tests. No duplicated extension lists, no raw C arrays, zero runtime cost.

### Decode-pipeline fixes for the RAW-side full decode

Getting the compare/switch RAW pane to a *genuine* full decode (not the camera's embedded preview) needed two fixes, found via instrumented debugging. The RAW codec keys on the `g_runtime.ForceRawDecode` global read at worker-thread time, which drove both:

1. **Texture-promotion upgrade path.** A RAW emits its embedded preview as a non-preview "final" event first, promoting the pane to quality level 2; the real LibRaw full decode arriving moments later was then discarded by the "already level 2, no upgrade path" guard. The guard now allows a genuine RAW full decode (`IsRawFullDecode`) to replace a resident frame that isn't one — a legitimate third-step upgrade the two-level model didn't anticipate.
2. **StartNavigation authority.** The pair file's own `StartNavigation` — the last to run before dispatch — asserts the correct `ForceRawDecode`, so a load interleaved by `EnterMode`'s message pumping can't strip the flag between arming and the worker reading it. The arming lambda captures by value because the async left-slot callback outlives the helper's locals.

The pair flows deliberately do **not** force-refresh the target's cache — the engine's own RAW quality check re-decodes a cached preview when full decode is wanted, so a still-cached full frame can be served instead of thrown away (whether it's still cached is up to the engine's memory policy).

## Upstream observation (not changed here)

While wiring `Shift+C` I noticed the toolbar comic-mode flag (`g_toolbar.IsComicMode()`) is only refreshed inside `StartNavigation`. Its double-page compare branches (`NavigateEdge`, `Navigate`) can therefore fire off a *stale* flag — e.g. after leaving a comic archive for a normal folder via a path that didn't run a full `StartNavigation`. The pairing code is immune to this by design (the StartNavigation-authority + by-value re-arming above), so I left the flag's update timing alone — it's your call whether to tighten it. Flagging it here for visibility.

## Commits (staged for review)

| # | Commit | What |
|---|--------|------|
| 1 | `refactor: centralize RAW/archive extension classification` | single-source `SupportedExtensions.h`, zero-cost predicates + static_asserts |
| 2 | `add rendered-pair whitelist and PairRawJpeg setting` | whitelist + config flag (off) |
| 3 | `fold same-name RAW+rendered pairs into one logical photo` | strict 1:1 core, both scan paths, resolved-path routing |
| 4 | `surface the hidden RAW across gallery, title and info panels` | `+CR3` everywhere |
| 5 | `verify pairs by exact EXIF capture-time match, asynchronously` | off-thread exact-second verify, split channel |
| 6 | `switch a paired item to its RAW via the RAW toggle` | `D` / toolbar button, pair-aware tooltips |
| 7 | `compare the two files of a pair side by side (Shift+C)` | pair-compare + synced pair navigation + decode fixes |
| 8 | `Settings toggle for RAW+JPEG pairing` | UI toggle, immediate re-fold |
| 9 | `three-way delete for a folded pair` | whole pair / RAW only / rendered only |

## Testing

- **35 unit tests** (gtest), all green: `SupportedExtensionsTests.cpp` (compile-time + runtime classification) and additions to `FileNavigatorTests.cpp` (strict 1:1 folding, verification split, skip-list). The pairing core is pure on its inputs, so it's directly unit-testable without the WIC/LibRaw stack.
- **Manual**: fold/unfold on toggle, all four visibility surfaces, `D` switch in single view, `Shift+C` genuine full decode + synced navigation + exit-to-rendered-face, exact-second split on a hand-mismatched pair, archive no-op, and the three-way delete (each choice, from both the rendered and RAW face, with Confirm-on-Delete on and off, recoverable from the Recycle Bin).

## Notes for the maintainer

- Default **off**; no behavior change unless enabled.
- No new third-party deps; reuses easyexif + LibRaw + WIC already in-tree.
- Follows the "no raw C arrays" rule throughout.
- Rebase target: `main` (fork tracks upstream). Diffstat: 19 files, +1690 / −143, of which 348 lines are new tests.
